### PR TITLE
Add suggestion review system (FLUFF-52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,104 @@
-# FluffBoost - Furry Motivation Discord Bot 🐾
+# FluffBoost - Your Daily Dose of Furry Motivation
 
 ![FluffBoost Banner](banner.jpg)
 
-Your Daily Dose of Furry Motivation! Let my friendly community bot deliver daily uplifting quotes and heartwarming messages to brighten your day. Whether you need inspiration, a positivity boost, or just a reason to smile, it’s here to make every day better.
+A furry-friendly Discord bot that delivers scheduled
+motivational quotes and heartwarming messages to your server.
+Whether you need inspiration, a positivity boost, or just
+a reason to smile, FluffBoost is here to make every day
+better with per-guild scheduling, premium subscriptions,
+and community-driven quotes.
 
-Celebrate furry culture and positivity with messages that inspire kindness, growth, and happiness. Together, let’s create a supportive and welcoming atmosphere.
-
-Start your day with a smile or find encouragement when you need it most. Let’s spread joy, one quote at a time!
+Spread joy, one quote at a time.
 
 ## Features
 
-- **Daily Motivational Quotes**: Automatically delivered to all configured server channels, with reliable delivery across shards.
-- **Per-Guild Scheduling**: Each server can set its own motivation time and timezone.
-- **Premium Subscriptions**: Optional premium tier via Discord App Subscriptions with custom quote scheduling (daily, weekly, or monthly), custom times, and timezone selection.
-- **Rotating Bot Status**: Customizable bot presence that cycles through activities on a configurable interval.
-- **Easy Integration**: Simple setup for any Discord server.
-- **Community-Driven**: Open-source development powered by furries, for furries! 🐺🐾
+- **Scheduled Motivational Quotes** — Automatically delivered
+  to configured channels on a per-guild schedule with reliable
+  delivery across shards.
+- **Per-Guild Scheduling** — Each server sets its own delivery
+  time and timezone.
+- **Premium Subscriptions** — Optional premium tier via Discord
+  App Subscriptions with custom frequency (daily, weekly, or
+  monthly), time, and timezone selection.
+- **Community Suggestions** — Users can suggest quotes for
+  server admins to review, approve, or reject.
+- **Rotating Bot Status** — Customizable bot presence that
+  cycles through activities on a configurable interval.
+- **Admin Dashboard** — Manage quotes, activities, and
+  suggestion reviews through slash commands.
+- **Health Check API** — Express-based health endpoint for
+  monitoring and orchestration.
+- **Sharded Architecture** — Scales across multiple shards
+  with Discord.js ShardingManager.
 
 ## Getting Started
 
-To add FluffBoost to your Discord server, follow these simple steps:
-
-1. Invite FluffBoost to your server using [this link](https://discord.com/api/oauth2/authorize?client_id=1152416549261561856&permissions=2147551232&scope=bot).
-2. Enjoy daily motivation and inspiration delivered to your server! 🎉
+1. Invite FluffBoost to your server using
+   [this link](https://discord.com/api/oauth2/authorize?client_id=1152416549261561856&permissions=2147551232&scope=bot).
+2. Use `/setup channel` to configure which channel receives
+   quotes.
+3. Enjoy daily motivation delivered to your server.
 
 ## Usage
 
-FluffBoost is user-friendly and easy to set up. Here’s a quick guide to the basic commands:
+FluffBoost uses Discord slash commands grouped by role.
 
-- `/about` - Learn about the bot and its creators.
-- `/invite` - Invite FluffBoost to your server.
-- `/quote` - Receive an instant motivational quote.
-- `/suggestion` - Make a quote suggestion for the owner to review.
-- `/setup` - Configure bot settings like the target channel for quotes (admin only).
-- `/setup schedule` - Customize quote delivery frequency, time, and timezone (premium).
-- `/premium` - View premium subscription info and status.
+### General Commands
 
-# Change Log
-For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
+| Command       | Description                              |
+| ------------- | ---------------------------------------- |
+| `/about`      | Learn about the bot and its creators     |
+| `/help`       | View available commands                  |
+| `/invite`     | Get the bot invite link                  |
+| `/quote`      | Receive an instant motivational quote    |
+| `/suggestion` | Suggest a quote for review               |
+| `/premium`    | View premium subscription info           |
+| `/changelog`  | View recent changes                      |
+
+### Admin Commands
+
+| Command                      | Description                        |
+| ---------------------------- | ---------------------------------- |
+| `/admin quote create`        | Add a new motivational quote       |
+| `/admin quote list`          | List all quotes                    |
+| `/admin quote remove`        | Remove a quote                     |
+| `/admin activity create`     | Add a bot status activity          |
+| `/admin activity list`       | List all activities                |
+| `/admin activity remove`     | Remove an activity                 |
+| `/admin suggestion approve`  | Approve a suggested quote          |
+| `/admin suggestion reject`   | Reject a suggested quote           |
+| `/admin suggestion list`     | List pending suggestions           |
+| `/admin suggestion stats`    | View suggestion statistics         |
+
+### Setup Commands
+
+| Command            | Description                              |
+| ------------------ | ---------------------------------------- |
+| `/setup channel`   | Set the quote delivery channel           |
+| `/setup schedule`  | Customize delivery frequency and time    |
+
+### Owner Commands
+
+| Command                      | Description                        |
+| ---------------------------- | ---------------------------------- |
+| `/owner premium test-create` | Create a test entitlement          |
+| `/owner premium test-delete` | Delete a test entitlement          |
+
+## Tech Stack
+
+| Layer            | Technology                               |
+| ---------------- | ---------------------------------------- |
+| Runtime          | Node.js 20.x / 22.x / 24.x             |
+| Language         | TypeScript 5.x (strict mode)            |
+| Discord Library  | Discord.js v14                           |
+| Database         | PostgreSQL 16 via Prisma 7               |
+| Job Queue        | BullMQ with Redis 7                      |
+| HTTP Server      | Express 5                                |
+| Analytics        | PostHog                                  |
+| Containerization | Docker (multi-stage, Node 24 Alpine)     |
+| CI/CD            | GitHub Actions                           |
+| Deployment       | Coolify                                  |
 
 ## Development
 
@@ -45,8 +106,9 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 - Node.js 20.x, 22.x, or 24.x
 - pnpm 9.x
-- PostgreSQL database
-- Redis server
+- PostgreSQL 16 (or use Docker Compose)
+- Redis 7 (or use Docker Compose)
+- A Discord application with bot token
 
 ### Setup
 
@@ -63,70 +125,105 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
    pnpm install
    ```
 
-3. Copy environment variables:
+3. Start local infrastructure:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+4. Copy and configure environment variables:
 
    ```bash
    cp .env.example .env
    ```
 
-4. Configure your environment variables in `.env`
-
-   - Optional: enable Redis debug logging by adding `DEBUG=ioredis:*` to your `.env` (the `.env.example` includes this line commented out).
-
-5. Generate Prisma client:
+5. Generate the Prisma client:
 
    ```bash
    pnpm db:generate
    ```
 
-6. Run database migrations:
+6. Sync the database schema:
+
    ```bash
    pnpm db:push
    ```
 
+7. Start the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
 ### Development Scripts
 
-- `pnpm dev` - Start development server with hot reload
-- `pnpm build` - Build the project for production
-- `pnpm start` - Start production server
-- `pnpm lint` - Run ESLint and auto-fix issues
-- `pnpm lint:check` - Check code style without fixing
-- `pnpm tsc --noEmit` - Run TypeScript type checking
-- `pnpm db:studio` - Open Prisma Studio to view/edit database
-- `pnpm test` - Run tests (131 tests across 20 files)
-- `pnpm test:coverage` - Run tests with c8 coverage report
+- `pnpm dev` — Start development server with hot reload
+- `pnpm build` — Compile TypeScript to `dist/`
+- `pnpm start` — Run compiled production build
+- `pnpm lint` — Run ESLint with auto-fix
+- `pnpm lint:check` — Check linting without fixing
+- `pnpm format` — Format code with Prettier
+- `pnpm tsc --noEmit` — Run TypeScript type checking
+- `pnpm db:generate` — Regenerate Prisma client
+- `pnpm db:push` — Sync schema to database (dev)
+- `pnpm db:migrate` — Run migrations (production)
+- `pnpm db:studio` — Open Prisma Studio UI
+- `pnpm test` — Run test suite (147 tests)
+- `pnpm test:coverage` — Run tests with c8 coverage
 
 ### Code Quality
 
-This project uses:
+- ESLint with TypeScript and Airbnb base config
+- Strict TypeScript (`noUnusedLocals`,
+  `noUnusedParameters`, `noImplicitReturns`,
+  `noUncheckedIndexedAccess`)
+- Mocha + Chai + Sinon + esmock test framework
+- c8 V8-based code coverage
+- supertest for HTTP endpoint testing
+- CI runs on Node 20.x, 22.x, and 24.x
 
-- **ESLint** with TypeScript support for code linting
-- **TypeScript** for type safety
-- **Prisma** for database management
-- **Consola** for centralized logging
-- **Mocha** + **Chai** + **Sinon** + **esmock** for testing (131 tests)
-- **c8** for V8-based code coverage
-- **supertest** for HTTP endpoint testing
+## Project Structure
 
-The CI pipeline automatically runs (on Node 20.x, 22.x, and 24.x):
+```
+fluffboost/
+├── src/
+│   ├── api/              # Express health-check API
+│   │   └── routes/       # API route handlers
+│   ├── commands/         # Discord slash commands
+│   │   ├── admin/        # Admin command group
+│   │   │   ├── activity/ # Bot activity management
+│   │   │   ├── quote/    # Quote management
+│   │   │   └── suggestion/ # Suggestion review
+│   │   ├── owner/        # Owner-only commands
+│   │   │   └── premium/  # Test entitlement commands
+│   │   └── setup/        # Server setup commands
+│   ├── database/         # Prisma client singleton
+│   ├── events/           # Discord event handlers
+│   ├── generated/        # Auto-generated Prisma client
+│   ├── redis/            # Redis/IORedis connection
+│   ├── utils/            # Shared utilities
+│   └── worker/           # BullMQ worker and jobs
+│       └── jobs/         # Job handlers
+├── tests/                # Test suite (mirrors src/)
+├── prisma/               # Prisma schema and migrations
+├── Dockerfile            # Multi-stage production build
+├── docker-compose.yml    # Local PostgreSQL + Redis
+└── docker-entrypoint.sh  # Migration runner for deploy
+```
 
-- Test execution with coverage reporting
-- TypeScript type checking
-- ESLint linting
-- Build verification
-- Security audits
-- Docker build tests
+## Changelog
+
+For detailed changelog information, see
+[CHANGELOG.md](CHANGELOG.md).
 
 ## License
 
-![GitHub license](https://img.shields.io/github/license/MrDemonWolf/fluffboost.svg?style=for-the-badge&logo=github)
+![GitHub license](https://img.shields.io/github/license/mrdemonwolf/fluffboost.svg?style=for-the-badge&logo=github)
 
 ## Contact
 
-If you have any questions, suggestions, or feedback, feel free to reach out to us on Discord!
+If you have any questions, suggestions, or feedback:
 
 - Discord: [Join my server](https://mrdwolf.net/discord)
 
-Thank you for choosing FluffBoost to add motivation and positivity to your Discord server!
-
-Made with ❤️ by <a href="https://www.mrdemonwolf.com">MrDemonWolf, Inc.</a>
+Made with love by [MrDemonWolf, Inc.](https://www.mrdemonwolf.com)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model SuggestionQuote {
   quote      String
   author     String
   addedBy    String
-  status     String    @default("pending")
+  status     String    @default("Pending")
   reviewedBy String?
   reviewedAt DateTime?
   createdAt  DateTime  @default(now())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,13 +46,15 @@ model MotivationQuote {
 }
 
 model SuggestionQuote {
-  id        String   @id @default(uuid())
-  quote     String
-  author    String
-  addedBy   String
-  status    String   @default("pending")
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  id         String    @id @default(uuid())
+  quote      String
+  author     String
+  addedBy    String
+  status     String    @default("pending")
+  reviewedBy String?
+  reviewedAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
 }
 
 model DiscordActivity {

--- a/src/commands/admin/index.ts
+++ b/src/commands/admin/index.ts
@@ -20,6 +20,10 @@ import quoteRemove from "./quote/remove.js";
 import activityAdd from "./activity/create.js";
 import activityList from "./activity/list.js";
 import activityRemove from "./activity/remove.js";
+import suggestionList from "./suggestion/list.js";
+import suggestionApprove from "./suggestion/approve.js";
+import suggestionReject from "./suggestion/reject.js";
+import suggestionStats from "./suggestion/stats.js";
 
 export const slashCommand = new SlashCommandBuilder()
   .setName("admin")
@@ -112,6 +116,60 @@ export const slashCommand = new SlashCommandBuilder()
           .setDescription("List all available activities");
       });
   })
+  .addSubcommandGroup((subCommandGroup) => {
+    return subCommandGroup
+      .setName("suggestion")
+      .setDescription("Manage quote suggestions")
+      .addSubcommand((subCommand) => {
+        return subCommand
+          .setName("list")
+          .setDescription("List quote suggestions")
+          .addStringOption((option) =>
+            option
+              .setName("status")
+              .setDescription("Filter by status")
+              .setRequired(false)
+              .addChoices(
+                { name: "Pending", value: "Pending" },
+                { name: "Approved", value: "Approved" },
+                { name: "Rejected", value: "Rejected" },
+              ),
+          );
+      })
+      .addSubcommand((subCommand) => {
+        return subCommand
+          .setName("approve")
+          .setDescription("Approve a quote suggestion")
+          .addStringOption((option) =>
+            option
+              .setName("suggestion_id")
+              .setDescription("The ID of the suggestion to approve")
+              .setRequired(true),
+          );
+      })
+      .addSubcommand((subCommand) => {
+        return subCommand
+          .setName("reject")
+          .setDescription("Reject a quote suggestion")
+          .addStringOption((option) =>
+            option
+              .setName("suggestion_id")
+              .setDescription("The ID of the suggestion to reject")
+              .setRequired(true),
+          )
+          .addStringOption((option) =>
+            option
+              .setName("reason")
+              .setDescription("Reason for rejection")
+              .setRequired(false),
+          );
+      })
+      .addSubcommand((subCommand) => {
+        return subCommand
+          .setName("stats")
+          .setDescription("View suggestion statistics");
+      });
+  })
   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
 
 export async function execute(client: Client, interaction: CommandInteraction) {
@@ -176,6 +234,39 @@ export async function execute(client: Client, interaction: CommandInteraction) {
             break;
           case "list":
             activityList(client, interaction);
+            break;
+          default:
+            interaction.reply({
+              content: "Invalid subcommand",
+              flags: MessageFlags.Ephemeral,
+            });
+        }
+        break;
+      case "suggestion":
+        switch (subCommand) {
+          case "list":
+            suggestionList(
+              client,
+              interaction,
+              options as CommandInteractionOptionResolver,
+            );
+            break;
+          case "approve":
+            suggestionApprove(
+              client,
+              interaction,
+              options as CommandInteractionOptionResolver,
+            );
+            break;
+          case "reject":
+            suggestionReject(
+              client,
+              interaction,
+              options as CommandInteractionOptionResolver,
+            );
+            break;
+          case "stats":
+            suggestionStats(client, interaction);
             break;
           default:
             interaction.reply({

--- a/src/commands/admin/index.ts
+++ b/src/commands/admin/index.ts
@@ -193,24 +193,24 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       case "quote":
         switch (subCommand) {
           case "create":
-            quoteCreate(
+            await quoteCreate(
               client,
               interaction,
               options as CommandInteractionOptionResolver
             );
             break;
           case "remove":
-            quoteRemove(
+            await quoteRemove(
               client,
               interaction,
               options as CommandInteractionOptionResolver
             );
             break;
           case "list":
-            quoteList(client, interaction);
+            await quoteList(client, interaction);
             break;
           default:
-            interaction.reply({
+            await interaction.reply({
               content: "Invalid subcommand",
               flags: MessageFlags.Ephemeral,
             });
@@ -219,24 +219,24 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       case "activity":
         switch (subCommand) {
           case "create":
-            activityAdd(
+            await activityAdd(
               client,
               interaction,
               options as CommandInteractionOptionResolver
             );
             break;
           case "remove":
-            activityRemove(
+            await activityRemove(
               client,
               interaction,
               options as CommandInteractionOptionResolver
             );
             break;
           case "list":
-            activityList(client, interaction);
+            await activityList(client, interaction);
             break;
           default:
-            interaction.reply({
+            await interaction.reply({
               content: "Invalid subcommand",
               flags: MessageFlags.Ephemeral,
             });
@@ -245,31 +245,31 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       case "suggestion":
         switch (subCommand) {
           case "list":
-            suggestionList(
+            await suggestionList(
               client,
               interaction,
               options as CommandInteractionOptionResolver,
             );
             break;
           case "approve":
-            suggestionApprove(
+            await suggestionApprove(
               client,
               interaction,
               options as CommandInteractionOptionResolver,
             );
             break;
           case "reject":
-            suggestionReject(
+            await suggestionReject(
               client,
               interaction,
               options as CommandInteractionOptionResolver,
             );
             break;
           case "stats":
-            suggestionStats(client, interaction);
+            await suggestionStats(client, interaction);
             break;
           default:
-            interaction.reply({
+            await interaction.reply({
               content: "Invalid subcommand",
               flags: MessageFlags.Ephemeral,
             });
@@ -277,7 +277,7 @@ export async function execute(client: Client, interaction: CommandInteraction) {
         break;
 
       default:
-        interaction.reply({
+        await interaction.reply({
           content: "Invalid subcommand group",
           flags: MessageFlags.Ephemeral,
         });

--- a/src/commands/admin/suggestion/approve.ts
+++ b/src/commands/admin/suggestion/approve.ts
@@ -1,0 +1,138 @@
+import {
+  Client,
+  CommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import type { CommandInteractionOptionResolver } from "discord.js";
+
+import { isUserPermitted } from "../../../utils/permissions.js";
+import { prisma } from "../../../database/index.js";
+import env from "../../../utils/env.js";
+import logger from "../../../utils/logger.js";
+
+export default async function (
+  client: Client,
+  interaction: CommandInteraction,
+  options: CommandInteractionOptionResolver,
+): Promise<any> {
+  try {
+    logger.commands.executing(
+      "admin suggestion approve",
+      interaction.user.username,
+      interaction.user.id,
+    );
+
+    const isAllowed = isUserPermitted(interaction);
+
+    if (!isAllowed) {
+      return;
+    }
+
+    const suggestionId = options.getString("suggestion_id", true);
+
+    const suggestion = await prisma.suggestionQuote.findUnique({
+      where: { id: suggestionId },
+    });
+
+    if (!suggestion) {
+      return await interaction.reply({
+        content: `Suggestion with ID ${suggestionId} not found.`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    if (suggestion.status !== "Pending") {
+      return await interaction.reply({
+        content: `This suggestion has already been ${suggestion.status.toLowerCase()}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    await prisma.motivationQuote.create({
+      data: {
+        quote: suggestion.quote,
+        author: suggestion.author,
+        addedBy: suggestion.addedBy,
+      },
+    });
+
+    await prisma.suggestionQuote.update({
+      where: { id: suggestionId },
+      data: {
+        status: "Approved",
+        reviewedBy: interaction.user.id,
+        reviewedAt: new Date(),
+      },
+    });
+
+    const embed = new EmbedBuilder()
+      .setColor(0x57f287)
+      .setTitle("Suggestion Approved")
+      .setAuthor({
+        name: interaction.user.username,
+        iconURL: interaction.user.displayAvatarURL(),
+      })
+      .addFields(
+        { name: "Quote", value: suggestion.quote },
+        { name: "Author", value: suggestion.author },
+        { name: "Submitted By", value: `<@${suggestion.addedBy}>` },
+      )
+      .setFooter({ text: `Suggestion ID: ${suggestionId}` })
+      .setTimestamp();
+
+    if (env.MAIN_CHANNEL_ID) {
+      const channel = await client.channels.fetch(env.MAIN_CHANNEL_ID);
+      if (channel?.isTextBased() && !channel.isDMBased()) {
+        await channel.send({ embeds: [embed] });
+      }
+    }
+
+    try {
+      const submitter = await client.users.fetch(suggestion.addedBy);
+      await submitter.send({
+        embeds: [
+          new EmbedBuilder()
+            .setColor(0x57f287)
+            .setTitle("Your Suggestion Was Approved!")
+            .setDescription(
+              `Your quote suggestion has been approved and added to the motivation quotes!\n\n` +
+                `**Quote:** ${suggestion.quote}\n**Author:** ${suggestion.author}`,
+            )
+            .setTimestamp(),
+        ],
+      });
+    } catch {
+      // DMs may be disabled — this is expected
+    }
+
+    await interaction.reply({
+      content: `Suggestion ${suggestionId} approved and added to motivation quotes.`,
+      flags: MessageFlags.Ephemeral,
+    });
+
+    logger.commands.success(
+      "admin suggestion approve",
+      interaction.user.username,
+      interaction.user.id,
+    );
+  } catch (err) {
+    logger.commands.error(
+      "admin suggestion approve",
+      interaction.user.username,
+      interaction.user.id,
+      err,
+    );
+    logger.error(
+      "Discord - Command",
+      "Error executing admin suggestion approve command",
+      err,
+      {
+        user: { username: interaction.user.username, id: interaction.user.id },
+        command: "admin suggestion approve",
+      },
+    );
+  }
+  return undefined;
+}

--- a/src/commands/admin/suggestion/list.ts
+++ b/src/commands/admin/suggestion/list.ts
@@ -11,7 +11,7 @@ export default async function (
   _client: Client,
   interaction: CommandInteraction,
   options: CommandInteractionOptionResolver,
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin suggestion list",
@@ -28,15 +28,19 @@ export default async function (
     const status = options.getString("status");
 
     const where = status ? { status } : {};
-    const suggestions = await prisma.suggestionQuote.findMany({ where });
+    const suggestions = await prisma.suggestionQuote.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+    });
 
     if (suggestions.length === 0) {
-      return await interaction.reply({
+      await interaction.reply({
         content: status
           ? `No suggestions found with status: ${status}`
           : "No suggestions found.",
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     let text = "ID - Quote - Author - Status - Submitted By\n";
@@ -75,6 +79,12 @@ export default async function (
         command: "admin suggestion list",
       },
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/admin/suggestion/list.ts
+++ b/src/commands/admin/suggestion/list.ts
@@ -1,0 +1,80 @@
+import { Client, CommandInteraction, MessageFlags } from "discord.js";
+
+import type { CommandInteractionOptionResolver } from "discord.js";
+import type { SuggestionQuote } from "../../../generated/prisma/client.js";
+
+import logger from "../../../utils/logger.js";
+import { isUserPermitted } from "../../../utils/permissions.js";
+import { prisma } from "../../../database/index.js";
+
+export default async function (
+  _client: Client,
+  interaction: CommandInteraction,
+  options: CommandInteractionOptionResolver,
+): Promise<any> {
+  try {
+    logger.commands.executing(
+      "admin suggestion list",
+      interaction.user.username,
+      interaction.user.id,
+    );
+
+    const isAllowed = isUserPermitted(interaction);
+
+    if (!isAllowed) {
+      return;
+    }
+
+    const status = options.getString("status");
+
+    const where = status ? { status } : {};
+    const suggestions = await prisma.suggestionQuote.findMany({ where });
+
+    if (suggestions.length === 0) {
+      return await interaction.reply({
+        content: status
+          ? `No suggestions found with status: ${status}`
+          : "No suggestions found.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    let text = "ID - Quote - Author - Status - Submitted By\n";
+    suggestions.forEach((s: SuggestionQuote) => {
+      text += `${s.id} - ${s.quote} - ${s.author} - ${s.status} - ${s.addedBy}\n`;
+    });
+
+    await interaction.reply({
+      files: [
+        {
+          attachment: Buffer.from(text),
+          name: "suggestions.txt",
+        },
+      ],
+      flags: MessageFlags.Ephemeral,
+    });
+
+    logger.commands.success(
+      "admin suggestion list",
+      interaction.user.username,
+      interaction.user.id,
+    );
+  } catch (err) {
+    logger.commands.error(
+      "admin suggestion list",
+      interaction.user.username,
+      interaction.user.id,
+      err,
+    );
+    logger.error(
+      "Discord - Command",
+      "Error executing admin suggestion list command",
+      err,
+      {
+        user: { username: interaction.user.username, id: interaction.user.id },
+        command: "admin suggestion list",
+      },
+    );
+  }
+  return undefined;
+}

--- a/src/commands/admin/suggestion/reject.ts
+++ b/src/commands/admin/suggestion/reject.ts
@@ -1,0 +1,140 @@
+import {
+  Client,
+  CommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+} from "discord.js";
+
+import type { CommandInteractionOptionResolver } from "discord.js";
+
+import { isUserPermitted } from "../../../utils/permissions.js";
+import { prisma } from "../../../database/index.js";
+import env from "../../../utils/env.js";
+import logger from "../../../utils/logger.js";
+
+export default async function (
+  client: Client,
+  interaction: CommandInteraction,
+  options: CommandInteractionOptionResolver,
+): Promise<any> {
+  try {
+    logger.commands.executing(
+      "admin suggestion reject",
+      interaction.user.username,
+      interaction.user.id,
+    );
+
+    const isAllowed = isUserPermitted(interaction);
+
+    if (!isAllowed) {
+      return;
+    }
+
+    const suggestionId = options.getString("suggestion_id", true);
+    const reason = options.getString("reason");
+
+    const suggestion = await prisma.suggestionQuote.findUnique({
+      where: { id: suggestionId },
+    });
+
+    if (!suggestion) {
+      return await interaction.reply({
+        content: `Suggestion with ID ${suggestionId} not found.`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    if (suggestion.status !== "Pending") {
+      return await interaction.reply({
+        content: `This suggestion has already been ${suggestion.status.toLowerCase()}.`,
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+
+    await prisma.suggestionQuote.update({
+      where: { id: suggestionId },
+      data: {
+        status: "Rejected",
+        reviewedBy: interaction.user.id,
+        reviewedAt: new Date(),
+      },
+    });
+
+    const embedFields = [
+      { name: "Quote", value: suggestion.quote },
+      { name: "Author", value: suggestion.author },
+      { name: "Submitted By", value: `<@${suggestion.addedBy}>` },
+    ];
+
+    if (reason) {
+      embedFields.push({ name: "Reason", value: reason });
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(0xed4245)
+      .setTitle("Suggestion Rejected")
+      .setAuthor({
+        name: interaction.user.username,
+        iconURL: interaction.user.displayAvatarURL(),
+      })
+      .addFields(embedFields)
+      .setFooter({ text: `Suggestion ID: ${suggestionId}` })
+      .setTimestamp();
+
+    if (env.MAIN_CHANNEL_ID) {
+      const channel = await client.channels.fetch(env.MAIN_CHANNEL_ID);
+      if (channel?.isTextBased() && !channel.isDMBased()) {
+        await channel.send({ embeds: [embed] });
+      }
+    }
+
+    try {
+      const submitter = await client.users.fetch(suggestion.addedBy);
+      const dmDescription = reason
+        ? `Your quote suggestion was rejected.\n\n` +
+          `**Quote:** ${suggestion.quote}\n**Author:** ${suggestion.author}\n**Reason:** ${reason}`
+        : `Your quote suggestion was rejected.\n\n` +
+          `**Quote:** ${suggestion.quote}\n**Author:** ${suggestion.author}`;
+
+      await submitter.send({
+        embeds: [
+          new EmbedBuilder()
+            .setColor(0xed4245)
+            .setTitle("Your Suggestion Was Rejected")
+            .setDescription(dmDescription)
+            .setTimestamp(),
+        ],
+      });
+    } catch {
+      // DMs may be disabled — this is expected
+    }
+
+    await interaction.reply({
+      content: `Suggestion ${suggestionId} has been rejected.`,
+      flags: MessageFlags.Ephemeral,
+    });
+
+    logger.commands.success(
+      "admin suggestion reject",
+      interaction.user.username,
+      interaction.user.id,
+    );
+  } catch (err) {
+    logger.commands.error(
+      "admin suggestion reject",
+      interaction.user.username,
+      interaction.user.id,
+      err,
+    );
+    logger.error(
+      "Discord - Command",
+      "Error executing admin suggestion reject command",
+      err,
+      {
+        user: { username: interaction.user.username, id: interaction.user.id },
+        command: "admin suggestion reject",
+      },
+    );
+  }
+  return undefined;
+}

--- a/src/commands/admin/suggestion/stats.ts
+++ b/src/commands/admin/suggestion/stats.ts
@@ -7,7 +7,7 @@ import logger from "../../../utils/logger.js";
 export default async function (
   _client: Client,
   interaction: CommandInteraction,
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin suggestion stats",
@@ -68,6 +68,12 @@ export default async function (
         command: "admin suggestion stats",
       },
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/admin/suggestion/stats.ts
+++ b/src/commands/admin/suggestion/stats.ts
@@ -1,0 +1,73 @@
+import { Client, CommandInteraction, EmbedBuilder, MessageFlags } from "discord.js";
+
+import { isUserPermitted } from "../../../utils/permissions.js";
+import { prisma } from "../../../database/index.js";
+import logger from "../../../utils/logger.js";
+
+export default async function (
+  _client: Client,
+  interaction: CommandInteraction,
+): Promise<any> {
+  try {
+    logger.commands.executing(
+      "admin suggestion stats",
+      interaction.user.username,
+      interaction.user.id,
+    );
+
+    const isAllowed = isUserPermitted(interaction);
+
+    if (!isAllowed) {
+      return;
+    }
+
+    const [pending, approved, rejected] = await Promise.all([
+      prisma.suggestionQuote.count({ where: { status: "Pending" } }),
+      prisma.suggestionQuote.count({ where: { status: "Approved" } }),
+      prisma.suggestionQuote.count({ where: { status: "Rejected" } }),
+    ]);
+
+    const total = pending + approved + rejected;
+    const approvalRate = total > 0 ? Math.round((approved / total) * 100) : 0;
+
+    const embed = new EmbedBuilder()
+      .setColor(0xfadb7f)
+      .setTitle("Suggestion Statistics")
+      .addFields(
+        { name: "Pending", value: `${pending}`, inline: true },
+        { name: "Approved", value: `${approved}`, inline: true },
+        { name: "Rejected", value: `${rejected}`, inline: true },
+        { name: "Total", value: `${total}`, inline: true },
+        { name: "Approval Rate", value: `${approvalRate}%`, inline: true },
+      )
+      .setTimestamp();
+
+    await interaction.reply({
+      embeds: [embed],
+      flags: MessageFlags.Ephemeral,
+    });
+
+    logger.commands.success(
+      "admin suggestion stats",
+      interaction.user.username,
+      interaction.user.id,
+    );
+  } catch (err) {
+    logger.commands.error(
+      "admin suggestion stats",
+      interaction.user.username,
+      interaction.user.id,
+      err,
+    );
+    logger.error(
+      "Discord - Command",
+      "Error executing admin suggestion stats command",
+      err,
+      {
+        user: { username: interaction.user.username, id: interaction.user.id },
+        command: "admin suggestion stats",
+      },
+    );
+  }
+  return undefined;
+}

--- a/src/commands/suggestion.ts
+++ b/src/commands/suggestion.ts
@@ -1,7 +1,6 @@
 import {
   Client,
   ChatInputCommandInteraction,
-  TextChannel,
   SlashCommandBuilder,
   EmbedBuilder,
   MessageFlags,
@@ -88,10 +87,6 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
     /**
      * Send the quote suggestion to the main channel for review
      */
-    const mainChannel = client.channels.cache.get(
-      env.MAIN_CHANNEL_ID as string
-    ) as TextChannel;
-
     const embed = new EmbedBuilder()
       .setColor(0xfadb7f)
       .setTitle("New Quote Suggestion")
@@ -118,9 +113,12 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
         text: `Created with ID ${newQuote.id}`,
       });
 
-    mainChannel?.send({
-      embeds: [embed],
-    });
+    if (env.MAIN_CHANNEL_ID) {
+      const mainChannel = await client.channels.fetch(env.MAIN_CHANNEL_ID);
+      if (mainChannel?.isTextBased() && !mainChannel.isDMBased()) {
+        await mainChannel.send({ embeds: [embed] });
+      }
+    }
 
     logger.commands.success(
       "suggestion",

--- a/src/commands/suggestion.ts
+++ b/src/commands/suggestion.ts
@@ -15,7 +15,7 @@ import posthog from "../utils/posthog.js";
 export const slashCommand = new SlashCommandBuilder()
   .setName("suggestion")
   .setDescription(
-    "Make a quote suggestion which will be reviewed by a the owner of the bot"
+    "Make a quote suggestion which will be reviewed by the owner of the bot"
   )
   .addStringOption((option) =>
     option

--- a/tests/commands/admin/suggestion/approve.test.ts
+++ b/tests/commands/admin/suggestion/approve.test.ts
@@ -1,0 +1,142 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient, mockEnv } from "../../../helpers.js";
+
+describe("admin suggestion approve command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule(overrides: { env?: Record<string, unknown> } = {}) {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv(overrides.env);
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/approve.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  function makeInteraction(suggestionId: string) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("suggestion_id", true).returns(suggestionId);
+    return interaction;
+  }
+
+  function makeClient() {
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const submitter = {
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+    (client.users.fetch as sinon.SinonStub).resolves(submitter);
+    return { client, channel, submitter };
+  }
+
+  it("should return error when suggestion not found", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("nonexistent");
+
+    prisma.suggestionQuote.findUnique.resolves(null);
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("not found");
+  });
+
+  it("should return error when already approved", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Be kind",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Approved",
+    });
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("already been approved");
+  });
+
+  it("should approve suggestion successfully", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+    const { client, channel, submitter } = makeClient();
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Be kind",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Pending",
+    });
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    // Creates motivation quote
+    expect(prisma.motivationQuote.create.calledOnce).to.be.true;
+    const createArgs = prisma.motivationQuote.create.firstCall.args[0];
+    expect(createArgs.data.quote).to.equal("Be kind");
+    expect(createArgs.data.author).to.equal("Anon");
+    expect(createArgs.data.addedBy).to.equal("user-1");
+
+    // Updates suggestion status
+    expect(prisma.suggestionQuote.update.calledOnce).to.be.true;
+    const updateArgs = prisma.suggestionQuote.update.firstCall.args[0];
+    expect(updateArgs.data.status).to.equal("Approved");
+    expect(updateArgs.data.reviewedBy).to.equal("user-123");
+
+    // Sends embed to main channel
+    expect(channel.send.calledOnce).to.be.true;
+
+    // DMs submitter
+    expect(submitter.send.calledOnce).to.be.true;
+
+    // Ephemeral reply to admin
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("approved");
+  });
+
+  it("should not break if DM fails", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+    const { client } = makeClient();
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Be kind",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Pending",
+    });
+
+    // Make user fetch throw to simulate DMs disabled
+    (client.users.fetch as sinon.SinonStub).rejects(new Error("Cannot send DM"));
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    // Should still reply successfully
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("approved");
+  });
+});

--- a/tests/commands/admin/suggestion/list.test.ts
+++ b/tests/commands/admin/suggestion/list.test.ts
@@ -1,0 +1,96 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockEnv } from "../../../helpers.js";
+
+describe("admin suggestion list command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule(overrides: { env?: Record<string, unknown> } = {}) {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv(overrides.env);
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleUnauthorized() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: mockEnv() },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  function makeInteraction(status: string | null = null) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("status").returns(status);
+    return interaction;
+  }
+
+  it("should deny unauthorized users", async () => {
+    const { handler, prisma } = await loadModuleUnauthorized();
+    const interaction = makeInteraction();
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect(prisma.suggestionQuote.findMany.called).to.be.false;
+  });
+
+  it("should return message when no suggestions found", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction();
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("No suggestions found");
+  });
+
+  it("should filter by status when provided", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("Pending");
+
+    prisma.suggestionQuote.findMany.resolves([]);
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect(prisma.suggestionQuote.findMany.calledOnce).to.be.true;
+    const findArgs = prisma.suggestionQuote.findMany.firstCall.args[0];
+    expect(findArgs.where.status).to.equal("Pending");
+  });
+
+  it("should return suggestions as a text file", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction();
+
+    prisma.suggestionQuote.findMany.resolves([
+      { id: "s1", quote: "Be kind", author: "Anon", status: "Pending", addedBy: "user-1" },
+      { id: "s2", quote: "Stay strong", author: "Me", status: "Approved", addedBy: "user-2" },
+    ]);
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.files).to.have.length(1);
+    expect(replyArgs.files[0].name).to.equal("suggestions.txt");
+  });
+});

--- a/tests/commands/admin/suggestion/reject.test.ts
+++ b/tests/commands/admin/suggestion/reject.test.ts
@@ -1,0 +1,158 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient, mockEnv } from "../../../helpers.js";
+
+describe("admin suggestion reject command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule(overrides: { env?: Record<string, unknown> } = {}) {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv(overrides.env);
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/reject.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  function makeInteraction(suggestionId: string, reason: string | null = null) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("suggestion_id", true).returns(suggestionId);
+    getStringStub.withArgs("reason").returns(reason);
+    return interaction;
+  }
+
+  function makeClient() {
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const submitter = {
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+    (client.users.fetch as sinon.SinonStub).resolves(submitter);
+    return { client, channel, submitter };
+  }
+
+  it("should return error when suggestion not found", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("nonexistent");
+
+    prisma.suggestionQuote.findUnique.resolves(null);
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("not found");
+  });
+
+  it("should return error when already rejected", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Be kind",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Rejected",
+    });
+
+    await handler({} as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("already been rejected");
+  });
+
+  it("should reject suggestion with reason", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1", "Not appropriate");
+    const { client, channel, submitter } = makeClient();
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Bad quote",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Pending",
+    });
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    // Updates suggestion status
+    expect(prisma.suggestionQuote.update.calledOnce).to.be.true;
+    const updateArgs = prisma.suggestionQuote.update.firstCall.args[0];
+    expect(updateArgs.data.status).to.equal("Rejected");
+    expect(updateArgs.data.reviewedBy).to.equal("user-123");
+
+    // Sends embed to main channel with reason
+    expect(channel.send.calledOnce).to.be.true;
+
+    // DMs submitter with reason
+    expect(submitter.send.calledOnce).to.be.true;
+    const dmEmbed = submitter.send.firstCall.args[0].embeds[0];
+    expect(dmEmbed.data.description).to.include("Not appropriate");
+
+    // Ephemeral reply
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("rejected");
+  });
+
+  it("should reject suggestion without reason", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+    const { client, submitter } = makeClient();
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Some quote",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Pending",
+    });
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(prisma.suggestionQuote.update.calledOnce).to.be.true;
+
+    // DM should not include "Reason"
+    const dmEmbed = submitter.send.firstCall.args[0].embeds[0];
+    expect(dmEmbed.data.description).to.not.include("Reason");
+  });
+
+  it("should not break if DM fails", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = makeInteraction("s1");
+    const { client } = makeClient();
+
+    prisma.suggestionQuote.findUnique.resolves({
+      id: "s1",
+      quote: "Some quote",
+      author: "Anon",
+      addedBy: "user-1",
+      status: "Pending",
+    });
+
+    (client.users.fetch as sinon.SinonStub).rejects(new Error("Cannot send DM"));
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("rejected");
+  });
+});

--- a/tests/commands/admin/suggestion/stats.test.ts
+++ b/tests/commands/admin/suggestion/stats.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockEnv } from "../../../helpers.js";
+
+describe("admin suggestion stats command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/stats.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: mockEnv() },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleUnauthorized() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/suggestion/stats.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: mockEnv() },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  it("should deny unauthorized users", async () => {
+    const { handler, prisma } = await loadModuleUnauthorized();
+    const interaction = mockInteraction();
+
+    await handler({} as never, interaction as never);
+
+    expect(prisma.suggestionQuote.count.called).to.be.false;
+  });
+
+  it("should return correct counts embed", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = mockInteraction();
+
+    const countStub = prisma.suggestionQuote.count;
+    countStub.withArgs({ where: { status: "Pending" } }).resolves(5);
+    countStub.withArgs({ where: { status: "Approved" } }).resolves(10);
+    countStub.withArgs({ where: { status: "Rejected" } }).resolves(3);
+
+    await handler({} as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    const embed = replyArgs.embeds[0];
+
+    expect(embed.data.title).to.equal("Suggestion Statistics");
+
+    const fields = embed.data.fields;
+    expect(fields[0].value).to.equal("5"); // Pending
+    expect(fields[1].value).to.equal("10"); // Approved
+    expect(fields[2].value).to.equal("3"); // Rejected
+    expect(fields[3].value).to.equal("18"); // Total
+    expect(fields[4].value).to.equal("56%"); // Approval rate (10/18)
+  });
+
+  it("should handle zero suggestions", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = mockInteraction();
+
+    prisma.suggestionQuote.count.resolves(0);
+
+    await handler({} as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    const fields = replyArgs.embeds[0].data.fields;
+    expect(fields[4].value).to.equal("0%"); // 0% approval rate when no suggestions
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -59,13 +59,17 @@ export function mockPrisma() {
     motivationQuote: {
       findMany: sinon.stub().resolves([]),
       count: sinon.stub().resolves(0),
+      create: sinon.stub().resolves({}),
     },
     discordActivity: {
       findMany: sinon.stub().resolves([]),
     },
     suggestionQuote: {
       findMany: sinon.stub().resolves([]),
+      findUnique: sinon.stub().resolves(null),
       create: sinon.stub().resolves({}),
+      update: sinon.stub().resolves({}),
+      count: sinon.stub().resolves(0),
     },
   };
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -94,6 +94,7 @@ export function mockInteraction(overrides: Record<string, unknown> = {}) {
     user: {
       id: "user-123",
       username: "testuser",
+      displayAvatarURL: sinon.stub().returns("https://example.com/avatar.png"),
     },
     guildId: "guild-123",
     replied: false,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -48,6 +48,7 @@ export function mockLogger() {
 
 export function mockPrisma() {
   return {
+    $transaction: sinon.stub().callsFake((promises: Promise<unknown>[]) => Promise.all(promises)),
     guild: {
       findMany: sinon.stub().resolves([]),
       findUnique: sinon.stub().resolves(null),


### PR DESCRIPTION
## Summary

- Add `/admin suggestion` subcommand group with `list`, `approve`, `reject`, and `stats` commands to complete the quote suggestion review lifecycle
- Add `reviewedBy` and `reviewedAt` fields to `SuggestionQuote` schema for audit tracking
- Fix `/suggestion` command to use `client.channels.fetch()` instead of `.cache.get()` per project conventions
- Add `displayAvatarURL` to `mockInteraction` test helper to support embed builder tests
- Rewrite README using the MrDemonWolf format with tech stack table, command tables grouped by role, project structure tree, and updated test count (147 tests)

## Details

**Schema changes:** Two new optional fields on `SuggestionQuote` — `reviewedBy` (String?) and `reviewedAt` (DateTime?) — to track who reviewed a suggestion and when.

**New commands:**
- `/admin suggestion list [status]` — List suggestions, optionally filtered by Pending/Approved/Rejected, returned as a `.txt` file attachment
- `/admin suggestion approve <suggestion_id>` — Approve a suggestion: creates a `MotivationQuote`, updates suggestion status, sends notification embed to main channel, DMs the submitter
- `/admin suggestion reject <suggestion_id> [reason]` — Reject a suggestion with optional reason, sends notification embed and DMs submitter
- `/admin suggestion stats` — Shows pending/approved/rejected counts with approval rate

**Bug fix:** `/suggestion` command now uses `client.channels.fetch()` instead of `client.channels.cache.get()` with proper `isTextBased()`/`isDMBased()` type guards.

**README rewrite:** Restructured with MrDemonWolf format — tech stack table, command tables grouped by role (General, Admin, Setup, Owner), project structure tree, expanded features list, and updated repo description/topics on GitHub.

**Test coverage:** 19 new tests covering all four suggestion subcommands (authorization, not found, already reviewed, success flows, DM failure resilience, stats calculations).

## Test plan

- [x] `pnpm db:generate` — Prisma client regenerated
- [x] `pnpm test` — All 147 tests pass (19 new)
- [x] `pnpm lint` — No lint errors
- [x] `pnpm tsc --noEmit` — No type errors
- [x] `pnpm build` — Compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can now manage suggestions: list/filter, approve, reject (with optional reason), and view approval stats.

* **Improvements**
  * Reviews are recorded with reviewer and timestamp; suggestion posting to the main channel is more robust.
  * Default suggestion status formatting updated.

* **Tests**
  * Comprehensive unit tests added for admin suggestion commands (approve, reject, list, stats).

* **Documentation**
  * README expanded into a comprehensive setup, usage, and developer guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->