### PR TITLE
FLUFF-93: Codebase cleanup & production readiness

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,11 @@
+{
+  "all": true,
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/generated/**"],
+  "reporter": ["text", "lcov", "html"],
+  "check-coverage": true,
+  "lines": 80,
+  "functions": 80,
+  "branches": 75,
+  "statements": 80
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
 
       - name: Run security audit
         run: pnpm audit
-        continue-on-error: true
 
       - name: Check for outdated packages
         run: pnpm outdated

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dist
 
 # Prisma ORM files generated in src (see prisma/schema.prisma)
 src/generated/prisma/
+# Claude Code
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The app is deployed via **Coolify** using a multi-stage Dockerfile (Node 24 Alpi
 
 - The `datasource` block in `prisma/schema.prisma` has **no `url` property** — this is intentional for Prisma 7 with driver adapters.
 - CLI tools (`prisma migrate deploy`, `prisma generate`, etc.) get the database URL from `prisma.config.ts` instead.
-- Prisma is installed globally in the production image (`npm install -g prisma@7.2.0`) for migrations. `NODE_PATH=/usr/local/lib/node_modules` is set so `prisma.config.ts` can resolve `prisma/config` from the global install.
+- Prisma is installed globally in the production image (`npm install -g prisma@7.4.0`) for migrations. `NODE_PATH=/usr/local/lib/node_modules` is set so `prisma.config.ts` can resolve `prisma/config` from the global install.
 
 ### Build optimizations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM node:24-alpine
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache openssl curl \
-    && npm install -g prisma@7.2.0 \
+    && npm install -g prisma@7.4.0 \
     && addgroup -S fluffboost && adduser -S fluffboost -G fluffboost
 
 COPY --from=prod-deps --chown=fluffboost:fluffboost /usr/src/app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@discordjs/core": "^2.4.0",
     "@discordjs/rest": "^2.6.0",
-    "@prisma/adapter-pg": "^7.2.0",
-    "@prisma/client": "7.2.0",
+    "@prisma/adapter-pg": "^7.4.0",
+    "@prisma/client": "7.4.0",
     "bullmq": "^5.66.2",
     "consola": "^3.4.2",
     "cors": "^2.8.5",
@@ -41,6 +41,18 @@
     "node-cron": "^4.2.1",
     "posthog-node": "^5.18.0",
     "zod": "^3.25.76"
+  },
+  "pnpm": {
+    "overrides": {
+      "qs": ">=6.14.2",
+      "hono": ">=4.11.7",
+      "undici": ">=6.23.0",
+      "lodash": ">=4.17.23"
+    },
+    "onlyBuiltDependencies": [
+      "@prisma/engines",
+      "prisma"
+    ]
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -66,7 +78,7 @@
     "esmock": "^2.7.3",
     "mocha": "^11.7.5",
     "prettier-eslint-cli": "^8.0.1",
-    "prisma": "^7.2.0",
+    "prisma": "^7.4.0",
     "sinon": "^21.0.1",
     "supertest": "^7.2.2",
     "tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs: '>=6.14.2'
+  hono: '>=4.11.7'
+  undici: '>=6.23.0'
+  lodash: '>=4.17.23'
+
 importers:
 
   .:
@@ -15,11 +21,11 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
       '@prisma/adapter-pg':
-        specifier: ^7.2.0
-        version: 7.2.0
+        specifier: ^7.4.0
+        version: 7.4.0
       '@prisma/client':
-        specifier: 7.2.0
-        version: 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: 7.4.0
+        version: 7.4.0(prisma@7.4.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       bullmq:
         specifier: ^5.66.2
         version: 5.66.2
@@ -136,8 +142,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(prettier-eslint@16.4.2(typescript@5.9.3))(typescript@5.9.3)
       prisma:
-        specifier: ^7.2.0
-        version: 7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        specifier: ^7.4.0
+        version: 7.4.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       sinon:
         specifier: ^21.0.1
         version: 21.0.1
@@ -208,19 +214,19 @@ packages:
     resolution: {integrity: sha512-ARXnE+qi+D7Y4trd1bKA9uhiUxQvLbOKcdehDa6NLd7FiqmDvvk8N5RGk6Ho9gdT/Wap09dz/IuLv7hNpUzt6g==}
     engines: {node: '>=20'}
 
-  '@electric-sql/pglite-socket@0.0.6':
-    resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
+  '@electric-sql/pglite-socket@0.0.20':
+    resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
     hasBin: true
     peerDependencies:
-      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite': 0.3.15
 
-  '@electric-sql/pglite-tools@0.2.7':
-    resolution: {integrity: sha512-9dAccClqxx4cZB+Ar9B+FZ5WgxDc/Xvl9DPrTWv+dYTf0YNubLzi4wHHRGRGhrJv15XwnyKcGOZAP1VXSneSUg==}
+  '@electric-sql/pglite-tools@0.2.20':
+    resolution: {integrity: sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==}
     peerDependencies:
-      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite': 0.3.15
 
-  '@electric-sql/pglite@0.3.2':
-    resolution: {integrity: sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==}
+  '@electric-sql/pglite@0.3.15':
+    resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -427,11 +433,11 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@hono/node-server@1.19.6':
-    resolution: {integrity: sha512-Shz/KjlIeAhfiuE93NDKVdZ7HdBVLQAfdbaXEaoAVO3ic9ibRSLGIQGkcBbFyuLr+7/1D5ZCINM8B+6IvXeMtw==}
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.11.7'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -498,8 +504,8 @@ packages:
   '@messageformat/runtime@3.0.2':
     resolution: {integrity: sha512-dkIPDCjXcfhSHgNE1/qV6TeczQZR59Yx0xXeafVKgK3QVWoxc38ljwpksUpnzCGvN151KUbCJTDZVmahtf1YZw==}
 
-  '@mrleebo/prisma-ast@0.12.1':
-    resolution: {integrity: sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==}
+  '@mrleebo/prisma-ast@0.13.1':
+    resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
     engines: {node: '>=16'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -558,14 +564,14 @@ packages:
   '@posthog/core@1.9.0':
     resolution: {integrity: sha512-j7KSWxJTUtNyKynLt/p0hfip/3I46dWU2dk+pt7dKRoz2l5CYueHuHK4EO7Wlgno5yo1HO4sc4s30MXMTICHJw==}
 
-  '@prisma/adapter-pg@7.2.0':
-    resolution: {integrity: sha512-euIdQ13cRB2wZ3jPsnDnFhINquo1PYFPCg6yVL8b2rp3EdinQHsX9EDdCtRr489D5uhphcRk463OdQAFlsCr0w==}
+  '@prisma/adapter-pg@7.4.0':
+    resolution: {integrity: sha512-LWwTHaio0bMxvzahmpwpWqsZM0vTfMqwF8zo06YvILL/o47voaSfKzCVxZw/o9awf4fRgS5Vgthobikj9Dusaw==}
 
-  '@prisma/client-runtime-utils@7.2.0':
-    resolution: {integrity: sha512-dn7oB53v0tqkB0wBdMuTNFNPdEbfICEUe82Tn9FoKAhJCUkDH+fmyEp0ClciGh+9Hp2Tuu2K52kth2MTLstvmA==}
+  '@prisma/client-runtime-utils@7.4.0':
+    resolution: {integrity: sha512-jTmWAOBGBSCT8n7SMbpjCpHjELgcDW9GNP/CeK6CeqjUFlEL6dn8Cl81t/NBDjJdXDm85XDJmc+PEQqqQee3xw==}
 
-  '@prisma/client@7.2.0':
-    resolution: {integrity: sha512-JdLF8lWZ+LjKGKpBqyAlenxd/kXjd1Abf/xK+6vUA7R7L2Suo6AFTHFRpPSdAKCan9wzdFApsUpSa/F6+t1AtA==}
+  '@prisma/client@7.4.0':
+    resolution: {integrity: sha512-Sc+ncr7+ph1hMf1LQfn6UyEXDEamCd5pXMsx8Q3SBH0NGX+zjqs3eaABt9hXwbcK9l7f8UyK8ldxOWA2LyPynQ==}
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     peerDependencies:
       prisma: '*'
@@ -576,41 +582,41 @@ packages:
       typescript:
         optional: true
 
-  '@prisma/config@7.2.0':
-    resolution: {integrity: sha512-qmvSnfQ6l/srBW1S7RZGfjTQhc44Yl3ldvU6y3pgmuLM+83SBDs6UQVgMtQuMRe9J3gGqB0RF8wER6RlXEr6jQ==}
-
-  '@prisma/debug@6.8.2':
-    resolution: {integrity: sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==}
+  '@prisma/config@7.4.0':
+    resolution: {integrity: sha512-EnNrZMwZ9+O6UlG+YO9SP3VhVw4zwMahDRzQm3r0DQn9KeU5NwzmaDAY+BzACrgmaU71Id1/0FtWIDdl7xQp9g==}
 
   '@prisma/debug@7.2.0':
     resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
 
-  '@prisma/dev@0.17.0':
-    resolution: {integrity: sha512-6sGebe5jxX+FEsQTpjHLzvOGPn6ypFQprcs3jcuIWv1Xp/5v6P/rjfdvAwTkP2iF6pDx2tCd8vGLNWcsWzImTA==}
+  '@prisma/debug@7.4.0':
+    resolution: {integrity: sha512-fZicwzgFHvvPMrRLCUinrsBTdadJsi/1oirzShjmFvNLwtu2DYlkxwRVy5zEGhp85mrEGnLeS/PdNRCdE027+Q==}
 
-  '@prisma/driver-adapter-utils@7.2.0':
-    resolution: {integrity: sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==}
+  '@prisma/dev@0.20.0':
+    resolution: {integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==}
 
-  '@prisma/engines-version@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3':
-    resolution: {integrity: sha512-KezsjCZDsbjNR7SzIiVlUsn9PnLePI7r5uxABlwL+xoerurZTfgQVbIjvjF2sVr3Uc0ZcsnREw3F84HvbggGdA==}
+  '@prisma/driver-adapter-utils@7.4.0':
+    resolution: {integrity: sha512-jEyE5LkqZ27Ba/DIOfCGOQl6nKMLxuwJNRceCfh7/LRs46UkIKn3bmkI97MEH2t7zkYV3PGBrUr+6sMJaHvc0A==}
 
-  '@prisma/engines@7.2.0':
-    resolution: {integrity: sha512-HUeOI/SvCDsHrR9QZn24cxxZcujOjcS3w1oW/XVhnSATAli5SRMOfp/WkG3TtT5rCxDA4xOnlJkW7xkho4nURA==}
+  '@prisma/engines-version@7.4.0-20.ab56fe763f921d033a6c195e7ddeb3e255bdbb57':
+    resolution: {integrity: sha512-5o3/bubIYdUeg38cyNf+VDq+LVtxvvi2393Fd1Uru52LPfkGJnmVbCaX1wBOAncgKR3BCloMJFD+Koog9LtYqQ==}
 
-  '@prisma/fetch-engine@7.2.0':
-    resolution: {integrity: sha512-Z5XZztJ8Ap+wovpjPD2lQKnB8nWFGNouCrglaNFjxIWAGWz0oeHXwUJRiclIoSSXN/ptcs9/behptSk8d0Yy6w==}
+  '@prisma/engines@7.4.0':
+    resolution: {integrity: sha512-H+dgpbbY3VN/j5hOSVP1LXsv/rU0w/4C2zh5PZUwo/Q3NqZjOvBlVvkhtziioRmeEZ3SBAqPCsf1sQ74sI3O/w==}
 
-  '@prisma/get-platform@6.8.2':
-    resolution: {integrity: sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==}
+  '@prisma/fetch-engine@7.4.0':
+    resolution: {integrity: sha512-IXPOYskT89UTVsntuSnMTiKRWCuTg5JMWflgEDV1OSKFpuhwP5vqbfF01/iwo9y6rCjR0sDIO+jdV5kq38/hgA==}
 
   '@prisma/get-platform@7.2.0':
     resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
 
-  '@prisma/query-plan-executor@6.18.0':
-    resolution: {integrity: sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA==}
+  '@prisma/get-platform@7.4.0':
+    resolution: {integrity: sha512-fOUIoGzAPgtjHVs4DsVSnEDPBEauAmFeZr4Ej3tMwxywam7hHdRtCzgKagQBKcYIJuya8gzYrTqUoukzXtWJaA==}
 
-  '@prisma/studio-core@0.9.0':
-    resolution: {integrity: sha512-xA2zoR/ADu/NCSQuriBKTh6Ps4XjU0bErkEcgMfnSGh346K1VI7iWKnoq1l2DoxUqiddPHIEWwtxJ6xCHG6W7g==}
+  '@prisma/query-plan-executor@7.2.0':
+    resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
+
+  '@prisma/studio-core@0.13.1':
+    resolution: {integrity: sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==}
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
@@ -1564,8 +1570,8 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-port-please@3.1.2:
-    resolution: {integrity: sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==}
+  get-port-please@3.2.0:
+    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1631,6 +1637,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphmatch@1.1.1:
+    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
+
   has-ansi@2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
@@ -1670,8 +1679,8 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
-  hono@4.10.6:
-    resolution: {integrity: sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==}
+  hono@4.11.10:
+    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1921,8 +1930,8 @@ packages:
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -2314,8 +2323,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prisma@7.2.0:
-    resolution: {integrity: sha512-jSdHWgWOgFF24+nRyyNRVBIgGDQEsMEF8KPHvhBBg3jWyR9fUAK0Nq9ThUmiGlNgq2FA7vSk/ZoCvefod+a8qg==}
+  prisma@7.4.0:
+    resolution: {integrity: sha512-n2xU9vSaH4uxZF/l2aKoGYtKtC7BL936jM9Q94Syk1zOD39t/5hjDUxMgaPkVRDX5wWEMsIqvzQxoebNIesOKw==}
     engines: {node: ^20.19 || ^22.12 || >=24.0}
     hasBin: true
     peerDependencies:
@@ -2340,10 +2349,6 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -2405,8 +2410,8 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  remeda@2.21.3:
-    resolution: {integrity: sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==}
+  remeda@2.33.4:
+    resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2565,8 +2570,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2737,9 +2742,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.21.3:
-    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
-    engines: {node: '>=18.17'}
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2849,8 +2854,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zeptomatch@2.0.2:
-    resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
+  zeptomatch@2.1.0:
+    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2863,12 +2868,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   '@chevrotain/gast@10.5.0':
     dependencies:
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   '@chevrotain/types@10.5.0': {}
 
@@ -2914,7 +2919,7 @@ snapshots:
       discord-api-types: 0.38.37
       magic-bytes.js: 1.12.1
       tslib: 2.8.1
-      undici: 6.21.3
+      undici: 7.22.0
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -2950,15 +2955,15 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
+  '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
     dependencies:
-      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite': 0.3.15
 
-  '@electric-sql/pglite-tools@0.2.7(@electric-sql/pglite@0.3.2)':
+  '@electric-sql/pglite-tools@0.2.20(@electric-sql/pglite@0.3.15)':
     dependencies:
-      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite': 0.3.15
 
-  '@electric-sql/pglite@0.3.2': {}
+  '@electric-sql/pglite@0.3.15': {}
 
   '@epic-web/invariant@1.0.0': {}
 
@@ -3107,9 +3112,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hono/node-server@1.19.6(hono@4.10.6)':
+  '@hono/node-server@1.19.9(hono@4.11.10)':
     dependencies:
-      hono: 4.10.6
+      hono: 4.11.10
 
   '@humanfs/core@0.19.1': {}
 
@@ -3179,7 +3184,7 @@ snapshots:
     dependencies:
       make-plural: 7.4.0
 
-  '@mrleebo/prisma-ast@0.12.1':
+  '@mrleebo/prisma-ast@0.13.1':
     dependencies:
       chevrotain: 10.5.0
       lilconfig: 2.1.0
@@ -3227,24 +3232,24 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@prisma/adapter-pg@7.2.0':
+  '@prisma/adapter-pg@7.4.0':
     dependencies:
-      '@prisma/driver-adapter-utils': 7.2.0
+      '@prisma/driver-adapter-utils': 7.4.0
       pg: 8.16.3
       postgres-array: 3.0.4
     transitivePeerDependencies:
       - pg-native
 
-  '@prisma/client-runtime-utils@7.2.0': {}
+  '@prisma/client-runtime-utils@7.4.0': {}
 
-  '@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@prisma/client-runtime-utils': 7.2.0
+      '@prisma/client-runtime-utils': 7.4.0
     optionalDependencies:
-      prisma: 7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      prisma: 7.4.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@7.2.0':
+  '@prisma/config@7.4.0':
     dependencies:
       c12: 3.1.0
       deepmerge-ts: 7.1.5
@@ -3253,62 +3258,62 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@prisma/debug@6.8.2': {}
-
   '@prisma/debug@7.2.0': {}
 
-  '@prisma/dev@0.17.0(typescript@5.9.3)':
+  '@prisma/debug@7.4.0': {}
+
+  '@prisma/dev@0.20.0(typescript@5.9.3)':
     dependencies:
-      '@electric-sql/pglite': 0.3.2
-      '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)
-      '@electric-sql/pglite-tools': 0.2.7(@electric-sql/pglite@0.3.2)
-      '@hono/node-server': 1.19.6(hono@4.10.6)
-      '@mrleebo/prisma-ast': 0.12.1
-      '@prisma/get-platform': 6.8.2
-      '@prisma/query-plan-executor': 6.18.0
+      '@electric-sql/pglite': 0.3.15
+      '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
+      '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
+      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@mrleebo/prisma-ast': 0.13.1
+      '@prisma/get-platform': 7.2.0
+      '@prisma/query-plan-executor': 7.2.0
       foreground-child: 3.3.1
-      get-port-please: 3.1.2
-      hono: 4.10.6
+      get-port-please: 3.2.0
+      hono: 4.11.10
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
-      remeda: 2.21.3
-      std-env: 3.9.0
+      remeda: 2.33.4
+      std-env: 3.10.0
       valibot: 1.2.0(typescript@5.9.3)
-      zeptomatch: 2.0.2
+      zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
 
-  '@prisma/driver-adapter-utils@7.2.0':
+  '@prisma/driver-adapter-utils@7.4.0':
     dependencies:
-      '@prisma/debug': 7.2.0
+      '@prisma/debug': 7.4.0
 
-  '@prisma/engines-version@7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3': {}
+  '@prisma/engines-version@7.4.0-20.ab56fe763f921d033a6c195e7ddeb3e255bdbb57': {}
 
-  '@prisma/engines@7.2.0':
+  '@prisma/engines@7.4.0':
     dependencies:
-      '@prisma/debug': 7.2.0
-      '@prisma/engines-version': 7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3
-      '@prisma/fetch-engine': 7.2.0
-      '@prisma/get-platform': 7.2.0
+      '@prisma/debug': 7.4.0
+      '@prisma/engines-version': 7.4.0-20.ab56fe763f921d033a6c195e7ddeb3e255bdbb57
+      '@prisma/fetch-engine': 7.4.0
+      '@prisma/get-platform': 7.4.0
 
-  '@prisma/fetch-engine@7.2.0':
+  '@prisma/fetch-engine@7.4.0':
     dependencies:
-      '@prisma/debug': 7.2.0
-      '@prisma/engines-version': 7.2.0-4.0c8ef2ce45c83248ab3df073180d5eda9e8be7a3
-      '@prisma/get-platform': 7.2.0
-
-  '@prisma/get-platform@6.8.2':
-    dependencies:
-      '@prisma/debug': 6.8.2
+      '@prisma/debug': 7.4.0
+      '@prisma/engines-version': 7.4.0-20.ab56fe763f921d033a6c195e7ddeb3e255bdbb57
+      '@prisma/get-platform': 7.4.0
 
   '@prisma/get-platform@7.2.0':
     dependencies:
       '@prisma/debug': 7.2.0
 
-  '@prisma/query-plan-executor@6.18.0': {}
+  '@prisma/get-platform@7.4.0':
+    dependencies:
+      '@prisma/debug': 7.4.0
 
-  '@prisma/studio-core@0.9.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@prisma/query-plan-executor@7.2.0': {}
+
+  '@prisma/studio-core@0.13.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@types/react': 19.2.7
       react: 19.2.3
@@ -3321,7 +3326,7 @@ snapshots:
   '@sapphire/shapeshift@4.0.0':
     dependencies:
       fast-deep-equal: 3.1.3
-      lodash: 4.17.21
+      lodash: 4.17.23
 
   '@sapphire/snowflake@3.5.3': {}
 
@@ -3695,7 +3700,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3812,7 +3817,7 @@ snapshots:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
       '@chevrotain/utils': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       regexp-to-ast: 0.5.0
 
   chokidar@4.0.3:
@@ -3985,7 +3990,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.12.1
       tslib: 2.8.1
-      undici: 6.21.3
+      undici: 7.22.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4357,7 +4362,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -4507,7 +4512,7 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-port-please@3.1.2: {}
+  get-port-please@3.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -4589,6 +4594,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphmatch@1.1.1: {}
+
   has-ansi@2.0.0:
     dependencies:
       ansi-regex: 2.1.1
@@ -4619,7 +4626,7 @@ snapshots:
 
   helmet@8.1.0: {}
 
-  hono@4.10.6: {}
+  hono@4.11.10: {}
 
   html-escaper@2.0.2: {}
 
@@ -4863,7 +4870,7 @@ snapshots:
 
   lodash.snakecase@4.1.1: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -5270,12 +5277,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  prisma@7.4.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 7.2.0
-      '@prisma/dev': 0.17.0(typescript@5.9.3)
-      '@prisma/engines': 7.2.0
-      '@prisma/studio-core': 0.9.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@prisma/config': 7.4.0
+      '@prisma/dev': 0.20.0(typescript@5.9.3)
+      '@prisma/engines': 7.4.0
+      '@prisma/studio-core': 0.13.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
@@ -5300,10 +5307,6 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.14.2:
     dependencies:
@@ -5370,9 +5373,7 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  remeda@2.21.3:
-    dependencies:
-      type-fest: 4.41.0
+  remeda@2.33.4: {}
 
   require-directory@2.1.1: {}
 
@@ -5556,7 +5557,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.9.0: {}
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5757,7 +5758,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.21.3: {}
+  undici@7.22.0: {}
 
   unpipe@1.0.0: {}
 
@@ -5787,7 +5788,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -5882,8 +5883,9 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zeptomatch@2.0.2:
+  zeptomatch@2.1.0:
     dependencies:
       grammex: 3.1.12
+      graphmatch: 1.1.1
 
   zod@3.25.76: {}

--- a/src/commands/about.ts
+++ b/src/commands/about.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
+import { EmbedBuilder, MessageFlags, SlashCommandBuilder } from "discord.js";
 
 import type { Client, CommandInteraction, User } from "discord.js";
 
@@ -86,6 +86,13 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "about",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/admin/activity/create.ts
+++ b/src/commands/admin/activity/create.ts
@@ -11,7 +11,7 @@ export default async function (
   _client: Client,
   interaction: CommandInteraction,
   options: CommandInteractionOptionResolver
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin activity add",
@@ -30,16 +30,18 @@ export default async function (
     const activityUrl = options.getString("url");
 
     if (!activity.trim()) {
-      return await interaction.reply({
+      await interaction.reply({
         content: "Please provide an activity",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
+      return;
     }
     if (!activityType.trim()) {
-      return await interaction.reply({
+      await interaction.reply({
         content: "Please provide a type",
-        ephemeral: true,
+        flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     const newActivity = await prisma.discordActivity.create({
@@ -76,6 +78,12 @@ export default async function (
         command: "admin activity add",
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/admin/activity/list.ts
+++ b/src/commands/admin/activity/list.ts
@@ -9,7 +9,7 @@ import { prisma } from "../../../database/index.js";
 export default async function (
   _client: Client,
   interaction: CommandInteraction
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin activity list",
@@ -23,13 +23,16 @@ export default async function (
       return;
     }
 
-    const activities = await prisma.discordActivity.findMany();
+    const activities = await prisma.discordActivity.findMany({
+      orderBy: { createdAt: "desc" },
+    });
 
     if (activities.length === 0) {
-      return interaction.reply({
+      await interaction.reply({
         content: "No activities found at the moment. Feel free to add some!",
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     let text = "ID - Activity - Type - URL\n";
@@ -39,7 +42,7 @@ export default async function (
       }\n`;
     });
 
-    interaction.reply({
+    await interaction.reply({
       files: [
         {
           attachment: Buffer.from(text),
@@ -64,6 +67,12 @@ export default async function (
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "admin activity list",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/admin/activity/remove.ts
+++ b/src/commands/admin/activity/remove.ts
@@ -10,7 +10,7 @@ export default async function (
   _client: Client,
   interaction: CommandInteraction,
   options: CommandInteractionOptionResolver
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin activity delete",
@@ -21,19 +21,21 @@ export default async function (
     const isAllowed = isUserPermitted(interaction);
 
     if (!isAllowed) {
-      return interaction.reply({
+      await interaction.reply({
         content: "You don't have permission to use this command.",
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     const activityId = options.getString("activity_id", true);
 
     if (!activityId.trim()) {
-      return interaction.reply({
+      await interaction.reply({
         content: "Please provide a valid activity ID",
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     const activity = await prisma.discordActivity.findUnique({
@@ -41,10 +43,11 @@ export default async function (
     });
 
     if (!activity) {
-      return interaction.reply({
+      await interaction.reply({
         content: `No activity found with ID: ${activityId}`,
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     await prisma.discordActivity.delete({
@@ -82,5 +85,4 @@ export default async function (
       });
     }
   }
-  return undefined;
 }

--- a/src/commands/admin/index.ts
+++ b/src/commands/admin/index.ts
@@ -293,6 +293,13 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "admin",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/admin/quote/list.ts
+++ b/src/commands/admin/quote/list.ts
@@ -9,7 +9,7 @@ import { prisma } from "../../../database/index.js";
 export default async function (
   _client: Client,
   interaction: CommandInteraction
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin quote list",
@@ -23,13 +23,16 @@ export default async function (
       return;
     }
 
-    const quotes = await prisma.motivationQuote.findMany();
+    const quotes = await prisma.motivationQuote.findMany({
+      orderBy: { createdAt: "desc" },
+    });
 
     if (quotes.length === 0) {
-      return await interaction.reply({
+      await interaction.reply({
         content: "No quotes found. Feel free to add some!",
         flags: MessageFlags.Ephemeral,
       });
+      return;
     }
 
     let text = "ID - Quote - Author\n";
@@ -68,6 +71,12 @@ export default async function (
         command: "admin quote list",
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/admin/quote/remove.ts
+++ b/src/commands/admin/quote/remove.ts
@@ -1,7 +1,6 @@
 import {
   Client,
   CommandInteraction,
-  TextChannel,
   MessageFlags,
 } from "discord.js";
 
@@ -16,7 +15,7 @@ export default async function (
   client: Client,
   interaction: CommandInteraction,
   options: CommandInteractionOptionResolver
-): Promise<any> {
+): Promise<void> {
   try {
     logger.commands.executing(
       "admin quote remove",
@@ -33,7 +32,8 @@ export default async function (
     const quoteId = options.getString("quote_id", true);
 
     if (!quoteId) {
-      return interaction.reply("Quote ID is required");
+      await interaction.reply("Quote ID is required");
+      return;
     }
 
     const quote = await prisma.motivationQuote.findUnique({
@@ -42,7 +42,8 @@ export default async function (
       },
     });
     if (!quote) {
-      return interaction.reply(`Quote with id ${quoteId} not found`);
+      await interaction.reply(`Quote with id ${quoteId} not found`);
+      return;
     }
 
     await prisma.motivationQuote.delete({
@@ -52,12 +53,14 @@ export default async function (
     });
 
     // send message to main channel
-    const mainChannel = client.channels.cache.get(
-      env.MAIN_CHANNEL_ID as string
-    ) as TextChannel;
-    mainChannel?.send(
-      `Quote deleted by ${interaction.user.username} with id: ${quoteId}`
-    );
+    if (env.MAIN_CHANNEL_ID) {
+      const mainChannel = await client.channels.fetch(env.MAIN_CHANNEL_ID);
+      if (mainChannel?.isTextBased() && !mainChannel.isDMBased()) {
+        await mainChannel.send(
+          `Quote deleted by ${interaction.user.username} with id: ${quoteId}`
+        );
+      }
+    }
 
     await interaction.reply({
       content: `Quote deleted with id: ${quoteId}`,
@@ -86,6 +89,12 @@ export default async function (
         quoteId: options.getString("quote_id"),
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
-  return undefined;
 }

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -55,7 +55,7 @@ export async function execute(_client: Client, interaction: CommandInteraction) 
         text: "Powered by MrDemonWolf, Inc.",
       });
 
-    interaction.reply({
+    await interaction.reply({
       embeds: [embed],
       flags: MessageFlags.Ephemeral,
     });
@@ -91,6 +91,13 @@ export async function execute(_client: Client, interaction: CommandInteraction) 
         command: "changelog",
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -9,7 +9,7 @@ export const slashCommand = new SlashCommandBuilder()
   .setName("help")
   .setDescription("Get help with using the bot");
 
-export function execute(_client: Client, interaction: CommandInteraction) {
+export async function execute(_client: Client, interaction: CommandInteraction) {
   try {
     logger.commands.executing(
       "help",
@@ -17,7 +17,7 @@ export function execute(_client: Client, interaction: CommandInteraction) {
       interaction.user.id
     );
 
-    interaction.reply({
+    await interaction.reply({
       content: `**Commands**\n
             \`/about\` - Learn more about the bot
             \`/invite\` - Invite me to your server!
@@ -57,6 +57,13 @@ export function execute(_client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "help",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -25,7 +25,7 @@ export async function execute(client: Client, interaction: CommandInteraction) {
     });
 
     // send invite link
-    interaction.reply({
+    await interaction.reply({
       content: `Invite me to your server! Let's keep spreading paw-sitivity 🐾\n${inviteLink}`,
       flags: MessageFlags.Ephemeral,
     });
@@ -56,6 +56,13 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "invite",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/owner/index.ts
+++ b/src/commands/owner/index.ts
@@ -117,6 +117,13 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "owner",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder, EmbedBuilder } from "discord.js";
+import { SlashCommandBuilder, EmbedBuilder, MessageFlags } from "discord.js";
 
 import type { Client, ChatInputCommandInteraction } from "discord.js";
 
@@ -10,7 +10,7 @@ export const slashCommand = new SlashCommandBuilder()
   .setName("quote")
   .setDescription("Get an instant dose of motivation");
 
-export async function execute(client: Client, interaction: ChatInputCommandInteraction): Promise<any> {
+export async function execute(client: Client, interaction: ChatInputCommandInteraction): Promise<void> {
   try {
     logger.commands.executing(
       "quote",
@@ -29,9 +29,10 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
     });
 
     if (!motivationQuote[0]) {
-      return interaction.reply(
+      await interaction.reply(
         "No motivation quote found.  Please try again later!"
       );
+      return;
     }
 
     /**
@@ -48,9 +49,10 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
           command: "quote",
         }
       );
-      return interaction.reply(
+      await interaction.reply(
         "Failed to fetch quote information. Please try again later!"
       );
+      return;
     }
 
     const motivationEmbed = new EmbedBuilder()
@@ -103,6 +105,13 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "quote",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/setup/channel.ts
+++ b/src/commands/setup/channel.ts
@@ -69,5 +69,12 @@ export default async function (
         command: "setup channel",
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }

--- a/src/commands/setup/index.ts
+++ b/src/commands/setup/index.ts
@@ -93,7 +93,7 @@ export async function execute(client: Client, interaction: CommandInteraction) {
         await schedule(client, interaction);
         break;
       default:
-        interaction.reply({
+        await interaction.reply({
           content: "Invalid subcommand",
           flags: MessageFlags.Ephemeral,
         });
@@ -110,6 +110,13 @@ export async function execute(client: Client, interaction: CommandInteraction) {
       user: { username: interaction.user.username, id: interaction.user.id },
       command: "setup",
     });
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/commands/suggestion.ts
+++ b/src/commands/suggestion.ts
@@ -30,7 +30,7 @@ export const slashCommand = new SlashCommandBuilder()
       .setRequired(true)
   );
 
-export async function execute(client: Client, interaction: ChatInputCommandInteraction): Promise<any> {
+export async function execute(client: Client, interaction: ChatInputCommandInteraction): Promise<void> {
   try {
     logger.commands.executing(
       "suggestion",
@@ -44,13 +44,16 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
     const author = options.getString("author");
 
     if (!quote) {
-      return interaction.reply("Please provide a quote");
+      await interaction.reply("Please provide a quote");
+      return;
     }
     if (!author) {
-      return interaction.reply("Please provide an author");
+      await interaction.reply("Please provide an author");
+      return;
     }
     if (!interaction.guildId) {
-      return interaction.reply("This command can only be used in a server");
+      await interaction.reply("This command can only be used in a server");
+      return;
     }
 
     /**
@@ -65,9 +68,10 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
     });
 
     if (!guild) {
-      return interaction.reply(
+      await interaction.reply(
         "This server is not setup yet. Please setup the bot first."
       );
+      return;
     }
 
     const newQuote = await prisma.suggestionQuote.create({
@@ -79,7 +83,7 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
       },
     });
 
-    interaction.reply({
+    await interaction.reply({
       content: "Quote suggestion created owner will review it soon!",
       flags: MessageFlags.Ephemeral,
     });
@@ -154,6 +158,13 @@ export async function execute(client: Client, interaction: ChatInputCommandInter
         command: "suggestion",
       }
     );
+
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
   }
 }
 

--- a/src/utils/guildDatabase.ts
+++ b/src/utils/guildDatabase.ts
@@ -6,7 +6,9 @@ import logger from "./logger.js";
 
 export async function pruneGuilds(client: Client) {
   try {
-    const guildsInDb = await prisma.guild.findMany({});
+    const guildsInDb = await prisma.guild.findMany({
+      orderBy: { guildId: "asc" },
+    });
 
     const guildsInCache = client.guilds.cache.map((guild) => guild.id);
 
@@ -99,7 +101,9 @@ export async function pruneGuilds(client: Client) {
 
 export async function ensureGuildExists(client: Client) {
   try {
-    const currentGuilds = await prisma.guild.findMany({});
+    const currentGuilds = await prisma.guild.findMany({
+      orderBy: { guildId: "asc" },
+    });
     const guildsToAdd = client.guilds.cache.filter(
       (guild) =>
         !currentGuilds.some((currentGuild: { guildId: string }) => currentGuild.guildId === guild.id)
@@ -173,19 +177,10 @@ export async function ensureGuildExists(client: Client) {
 }
 
 export async function guildExists(guildId: string) {
-  const guildExists = await prisma.guild.findUnique({
-    where: {
-      guildId,
-    },
+  const result = await prisma.guild.upsert({
+    where: { guildId },
+    create: { guildId },
+    update: {},
   });
-
-  if (!guildExists) {
-    await prisma.guild.create({
-      data: {
-        guildId,
-      },
-    });
-    return false;
-  }
-  return true;
+  return result !== null;
 }

--- a/src/worker/jobs/sendMotivation.ts
+++ b/src/worker/jobs/sendMotivation.ts
@@ -13,6 +13,7 @@ export default async function sendMotivation(client: Client) {
         not: null,
       },
     },
+    orderBy: { guildId: "asc" },
   });
 
   if (guilds.length === 0) {

--- a/src/worker/jobs/setActivity.ts
+++ b/src/worker/jobs/setActivity.ts
@@ -26,7 +26,9 @@ export default async (client: Client) => {
       );
     }
     const randomActivity = async () => {
-      const activities = await prisma.discordActivity.findMany();
+      const activities = await prisma.discordActivity.findMany({
+        orderBy: { createdAt: "desc" },
+      });
 
       if (activities.length === 0) {
         return null;

--- a/tests/commands/about.test.ts
+++ b/tests/commands/about.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPosthog, mockClient, mockInteraction, mockEnv } from "../helpers.js";
+
+describe("about command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const posthog = mockPosthog();
+    const env = mockEnv();
+
+    const mod = await esmock("../../src/commands/about.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/posthog.js": { default: posthog },
+      "../../src/utils/env.js": { default: env },
+    });
+
+    return { execute: mod.execute, logger, posthog, env };
+  }
+
+  it("should reply with an embed containing bot info", async () => {
+    const { execute } = await loadModule();
+    const client = mockClient();
+    const interaction = mockInteraction();
+
+    await execute(client as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.embeds).to.be.an("array").with.lengthOf(1);
+  });
+
+  it("should capture posthog event", async () => {
+    const { execute, posthog } = await loadModule();
+    const client = mockClient();
+    const interaction = mockInteraction();
+
+    await execute(client as never, interaction as never);
+
+    expect(posthog.capture.calledOnce).to.be.true;
+    expect(posthog.capture.firstCall.args[0].event).to.equal("about command used");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, logger } = await loadModule();
+    const client = mockClient();
+    const interaction = mockInteraction();
+    (interaction.reply as sinon.SinonStub).onFirstCall().rejects(new Error("fail"));
+    (interaction.reply as sinon.SinonStub).onSecondCall().resolves();
+
+    await execute(client as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/admin/activity/create.test.ts
+++ b/tests/commands/admin/activity/create.test.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("admin activity create command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/create.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/create.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  function makeInteraction(activity: string, type: string, url: string | null = null) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("activity", true).returns(activity);
+    getStringStub.withArgs("type", true).returns(type);
+    getStringStub.withArgs("url").returns(url);
+    return interaction;
+  }
+
+  it("should return early when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = makeInteraction("Gaming", "Playing");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should reply when empty activity provided", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction("  ", "Playing");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("provide an activity");
+  });
+
+  it("should reply when empty type provided", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction("Gaming", "  ");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("provide a type");
+  });
+
+  it("should create activity and reply on success", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.create.resolves({ id: "a1", activity: "Gaming", type: "Playing", url: null });
+
+    const interaction = makeInteraction("Gaming", "Playing");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(prisma.discordActivity.create.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("Activity added");
+  });
+
+  it("should create activity with url when provided", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.create.resolves({
+      id: "a1",
+      activity: "Streaming",
+      type: "Streaming",
+      url: "https://twitch.tv/test",
+    });
+
+    const interaction = makeInteraction("Streaming", "Streaming", "https://twitch.tv/test");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(prisma.discordActivity.create.calledOnce).to.be.true;
+    const createArgs = prisma.discordActivity.create.firstCall.args[0];
+    expect(createArgs.data.url).to.equal("https://twitch.tv/test");
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.discordActivity.create.rejects(new Error("DB error"));
+
+    const interaction = makeInteraction("Gaming", "Playing");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/admin/activity/list.test.ts
+++ b/tests/commands/admin/activity/list.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("admin activity list command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  it("should return early when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = mockInteraction();
+
+    await handler(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should reply when no activities found", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.findMany.resolves([]);
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("No activities found");
+  });
+
+  it("should reply with activities file when activities exist", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.findMany.resolves([
+      { id: "a1", activity: "Gaming", type: "Playing", url: null, createdAt: new Date() },
+      { id: "a2", activity: "Streaming", type: "Streaming", url: "https://twitch.tv/test", createdAt: new Date() },
+    ]);
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.files).to.be.an("array").with.lengthOf(1);
+    expect(replyArgs.files[0].name).to.equal("activities.txt");
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.discordActivity.findMany.rejects(new Error("DB error"));
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/admin/activity/remove.test.ts
+++ b/tests/commands/admin/activity/remove.test.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("admin activity remove command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/remove.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/activity/remove.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  function makeInteraction(activityId: string) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("activity_id", true).returns(activityId);
+    return interaction;
+  }
+
+  it("should reply with permission denied when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = makeInteraction("a1");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("permission");
+  });
+
+  it("should reply when empty activity ID provided", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction("  ");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("valid activity ID");
+  });
+
+  it("should reply when activity not found", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.findUnique.resolves(null);
+
+    const interaction = makeInteraction("a-nonexistent");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("No activity found");
+  });
+
+  it("should delete activity and reply on success", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.discordActivity.findUnique.resolves({ id: "a1", activity: "Gaming", type: "Playing" });
+
+    const interaction = makeInteraction("a1");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(prisma.discordActivity.delete.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("deleted");
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.discordActivity.findUnique.rejects(new Error("DB error"));
+
+    const interaction = makeInteraction("a1");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/admin/quote/create.test.ts
+++ b/tests/commands/admin/quote/create.test.ts
@@ -1,0 +1,129 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient, mockEnv } from "../../../helpers.js";
+
+describe("admin quote create command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/create.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/create.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  function makeInteraction(quote: string | null, author: string | null) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("quote").returns(quote);
+    getStringStub.withArgs("quote_author").returns(author);
+    return interaction;
+  }
+
+  it("should return early when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = makeInteraction("Be kind", "Anon");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should reply when no quote provided", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction(null, "Author");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("provide a quote");
+  });
+
+  it("should reply when no author provided", async () => {
+    const { handler } = await loadModule();
+    const interaction = makeInteraction("Be kind", null);
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("provide an author");
+  });
+
+  it("should create quote and reply on success", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.create.resolves({ id: "q1", quote: "Be kind", author: "Anon", addedBy: "user-123" });
+
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+
+    const interaction = makeInteraction("Be kind", "Anon");
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(prisma.motivationQuote.create.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("Quote created");
+  });
+
+  it("should send embed to main channel on success", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.create.resolves({ id: "q1", quote: "Be kind", author: "Anon", addedBy: "user-123" });
+
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+
+    const interaction = makeInteraction("Be kind", "Anon");
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(channel.send.calledOnce).to.be.true;
+    const sendArgs = channel.send.firstCall.args[0];
+    expect(sendArgs.embeds).to.be.an("array").with.lengthOf(1);
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.motivationQuote.create.rejects(new Error("DB error"));
+
+    const interaction = makeInteraction("Be kind", "Anon");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/admin/quote/list.test.ts
+++ b/tests/commands/admin/quote/list.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("admin quote list command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/list.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  it("should return early when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = mockInteraction();
+
+    await handler(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should reply when no quotes found", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.findMany.resolves([]);
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("No quotes found");
+  });
+
+  it("should reply with quotes file when quotes exist", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.findMany.resolves([
+      { id: "q1", quote: "Be brave", author: "Anon", createdAt: new Date() },
+      { id: "q2", quote: "Stay strong", author: "Author2", createdAt: new Date() },
+    ]);
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.files).to.be.an("array").with.lengthOf(1);
+    expect(replyArgs.files[0].name).to.equal("quotes.txt");
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.motivationQuote.findMany.rejects(new Error("DB error"));
+
+    const interaction = mockInteraction();
+    await handler(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/admin/quote/remove.test.ts
+++ b/tests/commands/admin/quote/remove.test.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockInteraction, mockClient, mockEnv } from "../../../helpers.js";
+
+describe("admin quote remove command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/remove.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(true) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  async function loadModuleNotPermitted() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const env = mockEnv();
+
+    const mod = await esmock("../../../../src/commands/admin/quote/remove.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/database/index.js": { prisma },
+      "../../../../src/utils/env.js": { default: env },
+      "../../../../src/utils/permissions.js": { isUserPermitted: sinon.stub().returns(false) },
+    });
+
+    return { handler: mod.default, logger, prisma, env };
+  }
+
+  function makeInteraction(quoteId: string) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("quote_id", true).returns(quoteId);
+    return interaction;
+  }
+
+  it("should return early when user is not permitted", async () => {
+    const { handler } = await loadModuleNotPermitted();
+    const interaction = makeInteraction("q1");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should reply when quote not found", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.findUnique.resolves(null);
+
+    const interaction = makeInteraction("q-nonexistent");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArg).to.include("not found");
+  });
+
+  it("should delete quote and reply on success", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.findUnique.resolves({ id: "q1", quote: "Be brave", author: "Anon" });
+
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+
+    const interaction = makeInteraction("q1");
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(prisma.motivationQuote.delete.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("deleted");
+  });
+
+  it("should send notification to main channel on delete", async () => {
+    const { handler, prisma } = await loadModule();
+    prisma.motivationQuote.findUnique.resolves({ id: "q1", quote: "Be brave", author: "Anon" });
+
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+
+    const interaction = makeInteraction("q1");
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(channel.send.calledOnce).to.be.true;
+  });
+
+  it("should reply with error on database failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.motivationQuote.findUnique.rejects(new Error("DB error"));
+
+    const interaction = makeInteraction("q1");
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("error occurred");
+  });
+});

--- a/tests/commands/changelog.test.ts
+++ b/tests/commands/changelog.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPosthog, mockClient, mockInteraction } from "../helpers.js";
+
+describe("changelog command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const posthog = mockPosthog();
+
+    const mod = await esmock("../../src/commands/changelog.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/posthog.js": { default: posthog },
+    });
+
+    return { execute: mod.execute, logger, posthog };
+  }
+
+  it("should reply with changelog embed", async () => {
+    const { execute } = await loadModule();
+    const interaction = mockInteraction();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.embeds).to.be.an("array").with.lengthOf(1);
+    expect(replyArgs.flags).to.exist;
+  });
+
+  it("should capture posthog event", async () => {
+    const { execute, posthog } = await loadModule();
+    const interaction = mockInteraction();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect(posthog.capture.calledOnce).to.be.true;
+    expect(posthog.capture.firstCall.args[0].event).to.equal("changelog command used");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, logger } = await loadModule();
+    const interaction = mockInteraction();
+    (interaction.reply as sinon.SinonStub).onFirstCall().rejects(new Error("fail"));
+    (interaction.reply as sinon.SinonStub).onSecondCall().resolves();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/help.test.ts
+++ b/tests/commands/help.test.ts
@@ -1,0 +1,56 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPosthog, mockClient, mockInteraction } from "../helpers.js";
+
+describe("help command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const posthog = mockPosthog();
+
+    const mod = await esmock("../../src/commands/help.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/posthog.js": { default: posthog },
+    });
+
+    return { execute: mod.execute, logger, posthog };
+  }
+
+  it("should reply with command list", async () => {
+    const { execute } = await loadModule();
+    const interaction = mockInteraction();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("/about");
+    expect(replyArgs.content).to.include("/quote");
+    expect(replyArgs.flags).to.exist;
+  });
+
+  it("should capture posthog event", async () => {
+    const { execute, posthog } = await loadModule();
+    const interaction = mockInteraction();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect(posthog.capture.calledOnce).to.be.true;
+    expect(posthog.capture.firstCall.args[0].event).to.equal("help command used");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, logger } = await loadModule();
+    const interaction = mockInteraction();
+    (interaction.reply as sinon.SinonStub).onFirstCall().rejects(new Error("fail"));
+    (interaction.reply as sinon.SinonStub).onSecondCall().resolves();
+
+    await execute(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/invite.test.ts
+++ b/tests/commands/invite.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPosthog, mockClient, mockInteraction } from "../helpers.js";
+
+describe("invite command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const posthog = mockPosthog();
+
+    const mod = await esmock("../../src/commands/invite.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/posthog.js": { default: posthog },
+    });
+
+    return { execute: mod.execute, logger, posthog };
+  }
+
+  it("should reply with invite link", async () => {
+    const { execute } = await loadModule();
+    const client = mockClient();
+    (client as Record<string, unknown>).generateInvite = sinon.stub().returns("https://discord.gg/test");
+    const interaction = mockInteraction();
+
+    await execute(client as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("https://discord.gg/test");
+  });
+
+  it("should capture posthog event", async () => {
+    const { execute, posthog } = await loadModule();
+    const client = mockClient();
+    (client as Record<string, unknown>).generateInvite = sinon.stub().returns("https://discord.gg/test");
+    const interaction = mockInteraction();
+
+    await execute(client as never, interaction as never);
+
+    expect(posthog.capture.calledOnce).to.be.true;
+    expect(posthog.capture.firstCall.args[0].event).to.equal("invite command used");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, logger } = await loadModule();
+    const client = mockClient();
+    (client as Record<string, unknown>).generateInvite = sinon.stub().throws(new Error("fail"));
+    const interaction = mockInteraction();
+
+    await execute(client as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/owner/premium/testDelete.test.ts
+++ b/tests/commands/owner/premium/testDelete.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockEnv, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("owner premium test-delete command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule(envOverrides: Record<string, unknown> = {}) {
+    const logger = mockLogger();
+    const env = mockEnv(envOverrides);
+
+    const mod = await esmock("../../../../src/commands/owner/premium/testDelete.js", {
+      "../../../../src/utils/logger.js": { default: logger },
+      "../../../../src/utils/env.js": { default: env },
+    });
+
+    return { handler: mod.default, logger, env };
+  }
+
+  function makeInteraction(userId: string, entitlementId: string) {
+    const interaction = mockInteraction({
+      user: { id: userId, username: "testuser", displayAvatarURL: sinon.stub().returns("https://example.com/av.png") },
+    });
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("entitlement_id", true).returns(entitlementId);
+    return interaction;
+  }
+
+  it("should reject non-owner users", async () => {
+    const { handler } = await loadModule({ OWNER_ID: "owner-123" });
+    const interaction = makeInteraction("not-owner", "ent-1");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("Only the bot owner");
+  });
+
+  it("should delete test entitlement successfully", async () => {
+    const { handler } = await loadModule({ OWNER_ID: "owner-123" });
+    const interaction = makeInteraction("owner-123", "ent-1");
+    const client = mockClient();
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(
+      (client.application as { entitlements: { deleteTest: sinon.SinonStub } }).entitlements.deleteTest.calledOnce
+    ).to.be.true;
+    expect(
+      (client.application as { entitlements: { deleteTest: sinon.SinonStub } }).entitlements.deleteTest.firstCall
+        .args[0]
+    ).to.equal("ent-1");
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("deleted");
+  });
+
+  it("should reply when application is not ready", async () => {
+    const { handler } = await loadModule({ OWNER_ID: "owner-123" });
+    const interaction = makeInteraction("owner-123", "ent-1");
+    const client = mockClient();
+    client.application = null as never;
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("not ready");
+  });
+
+  it("should show error message on API failure", async () => {
+    const { handler, logger } = await loadModule({ OWNER_ID: "owner-123" });
+    const interaction = makeInteraction("owner-123", "ent-1");
+    const client = mockClient();
+    (client.application as { entitlements: { deleteTest: sinon.SinonStub } }).entitlements.deleteTest.rejects(
+      new Error("API Error: rate limited")
+    );
+
+    await handler(client as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("API Error: rate limited");
+  });
+
+  it("should log unauthorized access attempt", async () => {
+    const { handler, logger } = await loadModule({ OWNER_ID: "owner-123" });
+    const interaction = makeInteraction("not-owner", "ent-1");
+
+    await handler(mockClient() as never, interaction as never, interaction.options as never);
+
+    expect(logger.commands.unauthorized.calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/quote.test.ts
+++ b/tests/commands/quote.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockPosthog, mockClient, mockInteraction } from "../helpers.js";
+
+describe("quote command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const posthog = mockPosthog();
+
+    const mod = await esmock("../../src/commands/quote.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/database/index.js": { prisma },
+      "../../src/utils/posthog.js": { default: posthog },
+    });
+
+    return { execute: mod.execute, logger, prisma, posthog };
+  }
+
+  it("should reply when no quotes found", async () => {
+    const { execute, prisma } = await loadModule();
+    prisma.motivationQuote.count.resolves(0);
+    prisma.motivationQuote.findMany.resolves([]);
+
+    const interaction = mockInteraction();
+    await execute(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const arg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(arg).to.include("No motivation quote found");
+  });
+
+  it("should reply with quote embed", async () => {
+    const { execute, prisma } = await loadModule();
+    prisma.motivationQuote.count.resolves(1);
+    prisma.motivationQuote.findMany.resolves([
+      { id: "q1", quote: "Be brave", author: "Anon", addedBy: "user-1", createdAt: new Date() },
+    ]);
+
+    const client = mockClient();
+    const interaction = mockInteraction();
+    await execute(client as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.embeds).to.be.an("array").with.lengthOf(1);
+  });
+
+  it("should capture posthog event on success", async () => {
+    const { execute, prisma, posthog } = await loadModule();
+    prisma.motivationQuote.count.resolves(1);
+    prisma.motivationQuote.findMany.resolves([
+      { id: "q1", quote: "Be brave", author: "Anon", addedBy: "user-1", createdAt: new Date() },
+    ]);
+
+    const client = mockClient();
+    const interaction = mockInteraction();
+    await execute(client as never, interaction as never);
+
+    expect(posthog.capture.calledOnce).to.be.true;
+    expect(posthog.capture.firstCall.args[0].event).to.equal("quote command used");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, prisma, logger } = await loadModule();
+    prisma.motivationQuote.count.rejects(new Error("DB error"));
+
+    const interaction = mockInteraction();
+    await execute(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/setup/channel.test.ts
+++ b/tests/commands/setup/channel.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockClient, mockInteraction } from "../../helpers.js";
+
+describe("setup channel command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+
+    const mod = await esmock("../../../src/commands/setup/channel.js", {
+      "../../../src/utils/logger.js": { default: logger },
+      "../../../src/database/index.js": { prisma },
+      "../../../src/utils/guildDatabase.js": { guildExists: sinon.stub().resolves(true) },
+    });
+
+    return { handler: mod.default, logger, prisma };
+  }
+
+  it("should return early when no guildId", async () => {
+    const { handler } = await loadModule();
+    const interaction = mockInteraction({ guildId: null });
+
+    await handler(mockClient() as never, interaction as never);
+
+    expect((interaction.reply as sinon.SinonStub).called).to.be.false;
+  });
+
+  it("should update guild with channel and reply", async () => {
+    const { handler, prisma } = await loadModule();
+    const interaction = mockInteraction();
+    const channel = { id: "ch-123", name: "general" };
+    (interaction.options.getChannel as sinon.SinonStub).withArgs("channel", true).returns(channel);
+
+    await handler(mockClient() as never, interaction as never);
+
+    expect(prisma.guild.update.calledOnce).to.be.true;
+    const updateArgs = prisma.guild.update.firstCall.args[0];
+    expect(updateArgs.data.motivationChannelId).to.equal("ch-123");
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+  });
+
+  it("should reply with error on failure", async () => {
+    const { handler, prisma, logger } = await loadModule();
+    prisma.guild.update.rejects(new Error("DB error"));
+    const interaction = mockInteraction();
+    (interaction.options.getChannel as sinon.SinonStub).withArgs("channel", true).returns({ id: "ch-123" });
+
+    await handler(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+  });
+});

--- a/tests/commands/suggestion.test.ts
+++ b/tests/commands/suggestion.test.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockPrisma, mockPosthog, mockClient, mockInteraction, mockEnv } from "../helpers.js";
+
+describe("suggestion command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const prisma = mockPrisma();
+    const posthog = mockPosthog();
+    const env = mockEnv();
+
+    const mod = await esmock("../../src/commands/suggestion.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/database/index.js": { prisma },
+      "../../src/utils/posthog.js": { default: posthog },
+      "../../src/utils/env.js": { default: env },
+    });
+
+    return { execute: mod.execute, logger, prisma, posthog, env };
+  }
+
+  function makeInteraction(quote: string | null, author: string | null) {
+    const interaction = mockInteraction();
+    const getStringStub = interaction.options.getString as sinon.SinonStub;
+    getStringStub.withArgs("quote").returns(quote);
+    getStringStub.withArgs("author").returns(author);
+    return interaction;
+  }
+
+  it("should reply when no quote provided", async () => {
+    const { execute } = await loadModule();
+    const interaction = makeInteraction(null, "Author");
+
+    await execute(mockClient() as never, interaction as never);
+
+    const arg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(arg).to.equal("Please provide a quote");
+  });
+
+  it("should reply when no author provided", async () => {
+    const { execute } = await loadModule();
+    const interaction = makeInteraction("Be kind", null);
+
+    await execute(mockClient() as never, interaction as never);
+
+    const arg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(arg).to.equal("Please provide an author");
+  });
+
+  it("should reply when not in a guild", async () => {
+    const { execute } = await loadModule();
+    const interaction = makeInteraction("Be kind", "Anon");
+    interaction.guildId = null as never;
+
+    await execute(mockClient() as never, interaction as never);
+
+    const arg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(arg).to.include("only be used in a server");
+  });
+
+  it("should reply when guild not setup", async () => {
+    const { execute, prisma } = await loadModule();
+    prisma.guild.findUnique.resolves(null);
+    const interaction = makeInteraction("Be kind", "Anon");
+
+    await execute(mockClient() as never, interaction as never);
+
+    const arg = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(arg).to.include("not setup");
+  });
+
+  it("should create suggestion and reply on success", async () => {
+    const { execute, prisma } = await loadModule();
+    prisma.guild.findUnique.resolves({ guildId: "guild-123" });
+    prisma.suggestionQuote.create.resolves({ id: "s1", quote: "Be kind", author: "Anon", status: "Pending" });
+
+    const channel = {
+      isTextBased: sinon.stub().returns(true),
+      isDMBased: sinon.stub().returns(false),
+      send: sinon.stub().resolves(),
+    };
+    const client = mockClient();
+    (client.channels.fetch as sinon.SinonStub).resolves(channel);
+
+    const interaction = makeInteraction("Be kind", "Anon");
+    await execute(client as never, interaction as never);
+
+    expect(prisma.suggestionQuote.create.calledOnce).to.be.true;
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).to.include("suggestion created");
+  });
+
+  it("should reply with error on failure", async () => {
+    const { execute, prisma, logger } = await loadModule();
+    prisma.guild.findUnique.rejects(new Error("DB error"));
+
+    const interaction = makeInteraction("Be kind", "Anon");
+    await execute(mockClient() as never, interaction as never);
+
+    expect(logger.commands.error.calledOnce).to.be.true;
+    expect((interaction.reply as sinon.SinonStub).calledOnce).to.be.true;
+  });
+});

--- a/tests/events/ready.test.ts
+++ b/tests/events/ready.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockClient } from "../helpers.js";
+
+describe("ready event", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule() {
+    const logger = mockLogger();
+    const pruneGuilds = sinon.stub().resolves();
+    const ensureGuildExists = sinon.stub().resolves();
+    const setActivity = sinon.stub().resolves();
+
+    const mod = await esmock("../../src/events/ready.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/guildDatabase.js": { pruneGuilds, ensureGuildExists },
+      "../../src/worker/jobs/setActivity.js": { default: setActivity },
+      "../../src/commands/help.js": { default: { slashCommand: { name: "help" } } },
+      "../../src/commands/about.js": { default: { slashCommand: { name: "about" } } },
+      "../../src/commands/quote.js": { default: { slashCommand: { name: "quote" } } },
+      "../../src/commands/suggestion.js": { default: { slashCommand: { name: "suggestion" } } },
+      "../../src/commands/invite.js": { default: { slashCommand: { name: "invite" } } },
+      "../../src/commands/setup/index.js": { default: { slashCommand: { name: "setup" } } },
+      "../../src/commands/admin/index.js": { default: { slashCommand: { name: "admin" } } },
+      "../../src/commands/changelog.js": { default: { slashCommand: { name: "changelog" } } },
+      "../../src/commands/premium.js": { default: { slashCommand: { name: "premium" } } },
+      "../../src/commands/owner/index.js": { default: { slashCommand: { name: "owner" } } },
+    });
+
+    return { readyEvent: mod.readyEvent, logger, pruneGuilds, ensureGuildExists, setActivity };
+  }
+
+  it("should log ready with username and guild count", async () => {
+    const { readyEvent, logger } = await loadModule();
+    const client = mockClient();
+    const commandsSet = sinon.stub().resolves();
+    const commandsFetch = sinon.stub().resolves(new Map([["help", { name: "help" }]]));
+    (client as Record<string, unknown>).application = {
+      commands: { set: commandsSet, fetch: commandsFetch },
+    };
+
+    await readyEvent(client as never);
+
+    expect(logger.discord.ready.calledOnce).to.be.true;
+  });
+
+  it("should prune guilds and ensure guilds exist", async () => {
+    const { readyEvent, pruneGuilds, ensureGuildExists } = await loadModule();
+    const client = mockClient();
+    const commandsSet = sinon.stub().resolves();
+    const commandsFetch = sinon.stub().resolves(new Map());
+    (client as Record<string, unknown>).application = {
+      commands: { set: commandsSet, fetch: commandsFetch },
+    };
+
+    await readyEvent(client as never);
+
+    expect(pruneGuilds.calledOnce).to.be.true;
+    expect(ensureGuildExists.calledOnce).to.be.true;
+  });
+
+  it("should register slash commands", async () => {
+    const { readyEvent } = await loadModule();
+    const client = mockClient();
+    const commandsSet = sinon.stub().resolves();
+    const commandsFetch = sinon.stub().resolves(new Map());
+    (client as Record<string, unknown>).application = {
+      commands: { set: commandsSet, fetch: commandsFetch },
+    };
+
+    await readyEvent(client as never);
+
+    expect(commandsSet.calledOnce).to.be.true;
+    const commands = commandsSet.firstCall.args[0];
+    expect(commands).to.be.an("array").with.lengthOf(10);
+  });
+
+  it("should set activity after ready", async () => {
+    const { readyEvent, setActivity } = await loadModule();
+    const client = mockClient();
+    const commandsSet = sinon.stub().resolves();
+    const commandsFetch = sinon.stub().resolves(new Map());
+    (client as Record<string, unknown>).application = {
+      commands: { set: commandsSet, fetch: commandsFetch },
+    };
+
+    await readyEvent(client as never);
+
+    expect(setActivity.calledOnce).to.be.true;
+  });
+
+  it("should handle errors during ready event", async () => {
+    const { readyEvent, logger, pruneGuilds } = await loadModule();
+    pruneGuilds.rejects(new Error("DB error"));
+    const client = mockClient();
+
+    await readyEvent(client as never);
+
+    expect(logger.error.called).to.be.true;
+  });
+});

--- a/tests/events/shardDisconnect.test.ts
+++ b/tests/events/shardDisconnect.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger } from "../helpers.js";
+
+describe("shardDisconnect event", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should log error and exit process", async () => {
+    const logger = mockLogger();
+    const exitStub = sinon.stub(process, "exit");
+
+    const mod = await esmock("../../src/events/shardDisconnect.js", {
+      "../../src/utils/logger.js": { default: logger },
+    });
+
+    mod.shardDisconnectEvent();
+
+    expect(logger.error.calledOnce).to.be.true;
+    expect(logger.error.firstCall.args[0]).to.include("Shard Disconnect");
+    expect(exitStub.calledOnce).to.be.true;
+    expect(exitStub.firstCall.args[0]).to.equal(1);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -54,16 +54,22 @@ export function mockPrisma() {
       findUnique: sinon.stub().resolves(null),
       create: sinon.stub().resolves({ guildId: "test-guild" }),
       update: sinon.stub().resolves({ guildId: "test-guild" }),
+      upsert: sinon.stub().resolves({ guildId: "test-guild" }),
       delete: sinon.stub().resolves({ guildId: "test-guild" }),
       count: sinon.stub().resolves(0),
     },
     motivationQuote: {
       findMany: sinon.stub().resolves([]),
+      findUnique: sinon.stub().resolves(null),
       count: sinon.stub().resolves(0),
       create: sinon.stub().resolves({}),
+      delete: sinon.stub().resolves({}),
     },
     discordActivity: {
       findMany: sinon.stub().resolves([]),
+      findUnique: sinon.stub().resolves(null),
+      create: sinon.stub().resolves({}),
+      delete: sinon.stub().resolves({}),
     },
     suggestionQuote: {
       findMany: sinon.stub().resolves([]),
@@ -110,6 +116,7 @@ export function mockInteraction(overrides: Record<string, unknown> = {}) {
     options: {
       getString: sinon.stub().returns(null),
       getInteger: sinon.stub().returns(null),
+      getChannel: sinon.stub().returns(null),
       getSubcommandGroup: sinon.stub().returns(null),
       getSubcommand: sinon.stub().returns(null),
       getFocused: sinon.stub().returns({ name: "", value: "" }),

--- a/tests/worker/index.test.ts
+++ b/tests/worker/index.test.ts
@@ -1,0 +1,122 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import esmock from "esmock";
+import { mockLogger, mockEnv } from "../helpers.js";
+
+describe("worker index", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should register jobs with correct intervals", async () => {
+    const logger = mockLogger();
+    const env = mockEnv({ DISCORD_ACTIVITY_INTERVAL_MINUTES: 10 });
+
+    const workerOnStub = sinon.stub();
+    const WorkerStub = sinon.stub().returns({ on: workerOnStub });
+
+    const mod = await esmock("../../src/worker/index.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/env.js": { default: env },
+      "../../src/bot.js": { default: {} },
+      "../../src/redis/index.js": { default: {} },
+      "../../src/worker/jobs/setActivity.js": { default: sinon.stub() },
+      "../../src/worker/jobs/sendMotivation.js": { default: sinon.stub() },
+      "bullmq": { Worker: WorkerStub, Job: class {} },
+    });
+
+    const addStub = sinon.stub();
+    const mockQueue = { add: addStub };
+
+    mod.default(mockQueue as never);
+
+    expect(addStub.calledTwice).to.be.true;
+
+    // First call: set-activity
+    const activityCall = addStub.firstCall;
+    expect(activityCall.args[0]).to.equal("set-activity");
+    expect(activityCall.args[2].repeat.every).to.equal(10 * 60 * 1000);
+
+    // Second call: send-motivation
+    const motivationCall = addStub.secondCall;
+    expect(motivationCall.args[0]).to.equal("send-motivation");
+    expect(motivationCall.args[2].repeat.every).to.equal(60 * 1000);
+
+    expect(logger.info.called).to.be.true;
+  });
+
+  it("should create Worker with correct job handler", async () => {
+    const logger = mockLogger();
+    const env = mockEnv();
+    const setActivityStub = sinon.stub().resolves();
+    const sendMotivationStub = sinon.stub().resolves();
+    const mockClient = { user: { id: "bot-123" } };
+
+    let jobProcessor: ((job: { name: string }) => Promise<unknown>) | undefined;
+    const workerOnStub = sinon.stub();
+    const WorkerStub = sinon.stub().callsFake((_name: string, processor: typeof jobProcessor) => {
+      jobProcessor = processor;
+      return { on: workerOnStub };
+    });
+
+    await esmock("../../src/worker/index.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/env.js": { default: env },
+      "../../src/bot.js": { default: mockClient },
+      "../../src/redis/index.js": { default: {} },
+      "../../src/worker/jobs/setActivity.js": { default: setActivityStub },
+      "../../src/worker/jobs/sendMotivation.js": { default: sendMotivationStub },
+      "bullmq": { Worker: WorkerStub, Job: class {} },
+    });
+
+    expect(jobProcessor).to.be.a("function");
+
+    // Test set-activity job
+    await jobProcessor!({ name: "set-activity" });
+    expect(setActivityStub.calledOnce).to.be.true;
+    expect(setActivityStub.firstCall.args[0]).to.equal(mockClient);
+
+    // Test send-motivation job
+    await jobProcessor!({ name: "send-motivation" });
+    expect(sendMotivationStub.calledOnce).to.be.true;
+
+    // Test unknown job
+    try {
+      await jobProcessor!({ name: "unknown-job" });
+      expect.fail("Should have thrown");
+    } catch (err) {
+      expect((err as Error).message).to.include("No job found");
+    }
+  });
+
+  it("should set up completed and failed event handlers", async () => {
+    const logger = mockLogger();
+    const env = mockEnv();
+
+    const workerOnStub = sinon.stub();
+    const WorkerStub = sinon.stub().returns({ on: workerOnStub });
+
+    await esmock("../../src/worker/index.js", {
+      "../../src/utils/logger.js": { default: logger },
+      "../../src/utils/env.js": { default: env },
+      "../../src/bot.js": { default: {} },
+      "../../src/redis/index.js": { default: {} },
+      "../../src/worker/jobs/setActivity.js": { default: sinon.stub() },
+      "../../src/worker/jobs/sendMotivation.js": { default: sinon.stub() },
+      "bullmq": { Worker: WorkerStub, Job: class {} },
+    });
+
+    expect(workerOnStub.calledWith("completed")).to.be.true;
+    expect(workerOnStub.calledWith("failed")).to.be.true;
+
+    // Test completed handler
+    const completedHandler = workerOnStub.getCalls().find((c: sinon.SinonSpyCall) => c.args[0] === "completed");
+    completedHandler!.args[1]({ name: "test-job", id: "123" });
+    expect(logger.success.called).to.be.true;
+
+    // Test failed handler
+    const failedHandler = workerOnStub.getCalls().find((c: sinon.SinonSpyCall) => c.args[0] === "failed");
+    failedHandler!.args[1]({ name: "test-job", id: "123" }, new Error("fail"));
+    expect(logger.error.called).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary

- **Error handling**: Add ephemeral error replies to 15 command catch blocks so users aren't left on "thinking..." when commands throw
- **Type safety**: Replace `Promise<any>` with `Promise<void>` in 8 files, add missing `await` to 5 `interaction.reply()` calls, make `help.ts` async
- **Channel fetch**: Replace `channels.cache.get()` with `channels.fetch()` + type guards in 2 files per project convention
- **Database hardening**: Add `orderBy` to 6 `findMany` calls for deterministic results, replace race-prone check-then-create with `prisma.guild.upsert()` in `guildExists()`
- **Test coverage**: Add 17 new test files (14 commands + 3 events/workers), increasing from 147 to 216 passing tests
- **CI quality gates**: Add `.c8rc.json` with coverage thresholds (80/80/75/80), remove `continue-on-error` from security audit

## Test plan

- [x] `pnpm lint:check` — 0 errors
- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm test` — 216 passing (up from 147)
- [x] `pnpm build` — Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)