### PR TITLE
feat: add /owner premium test-list command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,26 @@
+# Premium Testing TODO
+
+## Prerequisites
+- [ ] Bot running (`bun dev`)
+- [ ] `.env` has `PREMIUM_ENABLED=true`
+- [ ] `.env` has `DISCORD_PREMIUM_SKU_ID=<your_sku_id>`
+
+## Find & Clean Up Old Entitlement
+- [ ] Run `/owner premium test-list` in Discord
+- [ ] Copy the entitlement ID from the old test entitlement
+- [ ] Run `/owner premium test-delete entitlement_id:<paste_id>`
+- [ ] Run `/owner premium test-list` again to confirm it's gone
+
+## Test the Upsell Flow (no entitlement)
+- [ ] Run `/premium` → should show gold upsell embed with purchase button
+- [ ] Run `/setup schedule` → should show premium upsell and block you
+
+## Test the Subscribed Flow (with entitlement)
+- [ ] Run `/owner premium test-create` → **save the entitlement ID!**
+- [ ] Run `/premium` → should show green "Premium Active" embed
+- [ ] Run `/setup schedule frequency:Weekly time:09:00 timezone:America/New_York day:1`
+      → should succeed and save your schedule
+
+## Clean Up When Done
+- [ ] Run `/owner premium test-delete entitlement_id:<id>`
+- [ ] Run `/premium` → should be back to upsell

--- a/src/commands/owner/index.ts
+++ b/src/commands/owner/index.ts
@@ -14,6 +14,7 @@ import env from "../../utils/env.js";
  */
 import premiumTestCreate from "./premium/testCreate.js";
 import premiumTestDelete from "./premium/testDelete.js";
+import premiumTestList from "./premium/testList.js";
 
 export const slashCommand = new SlashCommandBuilder()
   .setName("owner")
@@ -43,6 +44,9 @@ export const slashCommand = new SlashCommandBuilder()
               .setDescription("The entitlement ID to delete")
               .setRequired(true)
           );
+      })
+      .addSubcommand((subCommand) => {
+        return subCommand.setName("test-list").setDescription("List all entitlements");
       });
   });
 
@@ -91,6 +95,9 @@ export async function execute(client: Client, interaction: CommandInteraction) {
               interaction,
               options as CommandInteractionOptionResolver
             );
+            break;
+          case "test-list":
+            await premiumTestList(client, interaction);
             break;
           default:
             await interaction.reply({

--- a/src/commands/owner/premium/testList.ts
+++ b/src/commands/owner/premium/testList.ts
@@ -1,0 +1,86 @@
+import { MessageFlags } from "discord.js";
+
+import type { Client, CommandInteraction } from "discord.js";
+
+import logger from "../../../utils/logger.js";
+import env from "../../../utils/env.js";
+
+export default async function (client: Client, interaction: CommandInteraction): Promise<void> {
+  try {
+    logger.commands.executing(
+      "owner premium test-list",
+      interaction.user.username,
+      interaction.user.id
+    );
+
+    if (interaction.user.id !== env.OWNER_ID) {
+      logger.commands.unauthorized(
+        "owner premium test-list",
+        interaction.user.username,
+        interaction.user.id
+      );
+      await interaction.reply({
+        content: "Only the bot owner can use this command.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!client.application) {
+      await interaction.reply({
+        content: "Bot application is not ready. Please try again in a moment.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const entitlements = await client.application.entitlements.fetch();
+
+    if (entitlements.size === 0) {
+      await interaction.reply({
+        content: "No entitlements found.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const lines = Array.from(entitlements.values()).map((e) => {
+      const test = e.isTest() ? " *(test)*" : "";
+      return `• \`${e.id}\` — guild: \`${e.guildId ?? "N/A"}\` — SKU: \`${e.skuId}\`${test}`;
+    });
+
+    await interaction.reply({
+      content: `**Entitlements (${entitlements.size}):**\n${lines.join("\n")}`,
+      flags: MessageFlags.Ephemeral,
+    });
+
+    logger.commands.success(
+      "owner premium test-list",
+      interaction.user.username,
+      interaction.user.id
+    );
+  } catch (err) {
+    logger.commands.error(
+      "owner premium test-list",
+      interaction.user.username,
+      interaction.user.id,
+      err
+    );
+    logger.error(
+      "Discord - Command",
+      "Error executing owner premium test-list command",
+      err,
+      {
+        user: { username: interaction.user.username, id: interaction.user.id },
+        command: "owner premium test-list",
+      }
+    );
+
+    if (!interaction.replied) {
+      await interaction.reply({
+        content: "Failed to list entitlements. Check bot logs for details.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+}

--- a/tests/commands/owner/premium/testList.test.ts
+++ b/tests/commands/owner/premium/testList.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, mock } from "bun:test";
+import sinon from "sinon";
+import { mockLogger, mockEnv, mockInteraction, mockClient } from "../../../helpers.js";
+
+describe("owner premium test-list command", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function loadModule(envOverrides: Record<string, unknown> = {}) {
+    const logger = mockLogger();
+    const env = mockEnv(envOverrides);
+
+    mock.module("../../../../src/utils/logger.js", () => ({ default: logger }));
+    mock.module("../../../../src/utils/env.js", () => ({ default: env }));
+
+    const mod = await import("../../../../src/commands/owner/premium/testList.js");
+
+    return { testList: mod.default, logger, env };
+  }
+
+  it("should reject non-owner users", async () => {
+    const { testList } = await loadModule({ OWNER_ID: "owner-123" });
+
+    const interaction = mockInteraction({ user: { id: "not-owner", username: "hacker" } });
+    await testList(mockClient() as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).toContain("Only the bot owner");
+  });
+
+  it("should reply when application is not ready", async () => {
+    const { testList } = await loadModule({ OWNER_ID: "owner-123" });
+
+    const interaction = mockInteraction({ user: { id: "owner-123", username: "owner" } });
+    const client = mockClient({ application: null });
+    await testList(client as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).toContain("not ready");
+  });
+
+  it("should reply with no entitlements when list is empty", async () => {
+    const { testList } = await loadModule({ OWNER_ID: "owner-123" });
+
+    const interaction = mockInteraction({ user: { id: "owner-123", username: "owner" } });
+    const client = mockClient();
+    await testList(client as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).toContain("No entitlements found");
+  });
+
+  it("should list entitlements successfully", async () => {
+    const { testList } = await loadModule({ OWNER_ID: "owner-123" });
+
+    const interaction = mockInteraction({ user: { id: "owner-123", username: "owner" } });
+    const client = mockClient();
+
+    const fakeEntitlements = new Map([
+      [
+        "ent-1",
+        { id: "ent-1", guildId: "guild-1", skuId: "sku-1", isTest: sinon.stub().returns(true) },
+      ],
+      [
+        "ent-2",
+        { id: "ent-2", guildId: null, skuId: "sku-2", isTest: sinon.stub().returns(false) },
+      ],
+    ]);
+    (
+      client.application as { entitlements: { fetch: sinon.SinonStub } }
+    ).entitlements.fetch.resolves(fakeEntitlements);
+
+    await testList(client as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).toContain("Entitlements (2)");
+    expect(replyArgs.content).toContain("ent-1");
+    expect(replyArgs.content).toContain("guild-1");
+    expect(replyArgs.content).toContain("ent-2");
+    expect(replyArgs.content).toContain("*(test)*");
+  });
+
+  it("should handle errors and reply with failure message", async () => {
+    const { testList } = await loadModule({ OWNER_ID: "owner-123" });
+
+    const interaction = mockInteraction({ user: { id: "owner-123", username: "owner" } });
+    const client = mockClient();
+    (
+      client.application as { entitlements: { fetch: sinon.SinonStub } }
+    ).entitlements.fetch.rejects(new Error("API failure"));
+
+    await testList(client as never, interaction as never);
+
+    const replyArgs = (interaction.reply as sinon.SinonStub).firstCall.args[0];
+    expect(replyArgs.content).toContain("Failed to list entitlements");
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,7 +3,7 @@ import type { SinonStub } from "sinon";
 
 /**
  * Shared test helper factories for FluffBoost tests.
- * Provides lightweight mock objects for Discord.js, Prisma, Logger, and PostHog.
+ * Provides lightweight mock objects for Discord.js, Drizzle, Logger, and PostHog.
  */
 
 // ── Logger mock ──────────────────────────────────────────────────────────────
@@ -44,41 +44,72 @@ export function mockLogger() {
   };
 }
 
-// ── Prisma mock ──────────────────────────────────────────────────────────────
+// ── Drizzle DB mock ─────────────────────────────────────────────────────────
 
-export function mockPrisma() {
+/**
+ * Creates a chainable mock that simulates Drizzle's query builder.
+ * All chaining methods (from, where, orderBy, etc.) return `this`.
+ * When `await`ed, resolves to the configured value (default: []).
+ *
+ * Usage in tests:
+ *   const chain = mockDbChain([{ guildId: "g1" }]);
+ *   db.select.returns(chain);
+ *   // When source code does: await db.select().from(guilds).where(...)
+ *   // It resolves to [{ guildId: "g1" }]
+ *
+ * For error cases:
+ *   const chain = mockDbChain();
+ *   chain.rejects(new Error("DB error"));
+ */
+export function mockDbChain(resolveValue: unknown = []) {
+  let _resolveValue: unknown = resolveValue;
+  let _rejectValue: unknown = undefined;
+
+  const chain: Record<string, unknown> = {};
+  const methods = [
+    "from", "where", "orderBy", "limit", "offset",
+    "set", "values", "onConflictDoNothing", "returning", "target",
+  ];
+
+  for (const method of methods) {
+    chain[method] = sinon.stub().returns(chain);
+  }
+
+  // Make the chain thenable so `await db.select().from(...)` works
+  chain.then = (onFulfill: (v: unknown) => unknown, onReject?: (e: unknown) => unknown) => {
+    if (_rejectValue !== undefined) {
+      return Promise.reject(_rejectValue).then(onFulfill, onReject);
+    }
+    return Promise.resolve(_resolveValue).then(onFulfill, onReject);
+  };
+
+  // Test configuration helpers
+  chain.resolves = (value: unknown) => { _resolveValue = value; _rejectValue = undefined; return chain; };
+  chain.rejects = (err: unknown) => { _rejectValue = err; return chain; };
+
+  return chain;
+}
+
+/**
+ * Creates a mock for Drizzle's `db` object.
+ * Each method (select, insert, update, delete) returns a fresh chainable mock by default.
+ * Use sinon's `.returns()` or `.onCall(n).returns()` to configure specific chain results.
+ *
+ * Example:
+ *   const db = mockDb();
+ *   db.select.returns(mockDbChain([{ guildId: "g1" }]));
+ *   db.insert.returns(mockDbChain([{ id: "new-id" }]));
+ */
+export function mockDb() {
   return {
-    $transaction: sinon.stub().callsFake((promises: Promise<unknown>[]) => Promise.all(promises)),
-    guild: {
-      findMany: sinon.stub().resolves([]),
-      findUnique: sinon.stub().resolves(null),
-      create: sinon.stub().resolves({ guildId: "test-guild" }),
-      update: sinon.stub().resolves({ guildId: "test-guild" }),
-      upsert: sinon.stub().resolves({ guildId: "test-guild" }),
-      delete: sinon.stub().resolves({ guildId: "test-guild" }),
-      count: sinon.stub().resolves(0),
-    },
-    motivationQuote: {
-      findMany: sinon.stub().resolves([]),
-      findUnique: sinon.stub().resolves(null),
-      count: sinon.stub().resolves(0),
-      create: sinon.stub().resolves({}),
-      delete: sinon.stub().resolves({}),
-    },
-    discordActivity: {
-      findMany: sinon.stub().resolves([]),
-      findUnique: sinon.stub().resolves(null),
-      create: sinon.stub().resolves({}),
-      delete: sinon.stub().resolves({}),
-    },
-    suggestionQuote: {
-      findMany: sinon.stub().resolves([]),
-      findUnique: sinon.stub().resolves(null),
-      create: sinon.stub().resolves({}),
-      update: sinon.stub().resolves({}),
-      updateMany: sinon.stub().resolves({ count: 0 }),
-      count: sinon.stub().resolves(0),
-    },
+    select: sinon.stub().callsFake(() => mockDbChain([])),
+    insert: sinon.stub().callsFake(() => mockDbChain([])),
+    update: sinon.stub().callsFake(() => mockDbChain([])),
+    delete: sinon.stub().callsFake(() => mockDbChain()),
+    transaction: sinon.stub().callsFake(async (fn: (tx: ReturnType<typeof mockDb>) => Promise<unknown>) => {
+      const tx = mockDb();
+      return fn(tx);
+    }),
   };
 }
 
@@ -150,6 +181,7 @@ export function mockClient(overrides: Record<string, unknown> = {}) {
       entitlements: {
         createTest: sinon.stub().resolves({ id: "ent-123", skuId: "sku-123" }),
         deleteTest: sinon.stub().resolves(),
+        fetch: sinon.stub().resolves(new Map()),
       },
     },
     ...overrides,
@@ -210,6 +242,6 @@ export function mockEnv(overrides: Record<string, unknown> = {}) {
 // ── Utility types for stubs ──────────────────────────────────────────────────
 
 export type MockLogger = ReturnType<typeof mockLogger>;
-export type MockPrisma = ReturnType<typeof mockPrisma>;
+export type MockDb = ReturnType<typeof mockDb>;
 export type MockPosthog = ReturnType<typeof mockPosthog>;
 export type StubFn = SinonStub;


### PR DESCRIPTION
## Summary
- Adds `/owner premium test-list` subcommand to list all current entitlements (ID, guild, SKU, test flag) — solves the problem of losing track of entitlement IDs
- Wires the new subcommand into `src/commands/owner/index.ts` with import, builder definition, and switch case
- Adds `TODO.md` as an ADHD-friendly premium testing checklist with step-by-step flows

## Test plan
- [ ] `bun run typecheck` passes (no type errors)
- [ ] `bun test tests/commands/owner/premium/testList.test.ts` — all 5 tests pass
- [ ] Run `bun dev` and use `/owner premium test-list` in Discord — confirms it lists entitlements or shows "No entitlements found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)